### PR TITLE
Add .dependencyLicenses file for JavaScript dependencies

### DIFF
--- a/.dependencyLicenses
+++ b/.dependencyLicenses
@@ -1,0 +1,8 @@
+./igs/server/input/content/assets/js/heading-links.js
+./igs/diga/input/content/assets/js/heading-links.js
+./igs/rx/input/content/assets/js/heading-links.js
+./igs/erp-chrg/input/content/assets/js/heading-links.js
+./igs/core/input/content/assets/js/heading-links.js
+./igs/t-register/input/content/assets/js/heading-links.js
+./igs/erp-eu/input/pagecontent/assets/js/heading-links.js
+./igs/erp-eu/input/content/assets/js/heading-links.js


### PR DESCRIPTION
Introduce a .dependencyLicenses file that lists all JavaScript dependencies used across various components.