### PR TITLE
Add example FSH files for various operations and update documentation

### DIFF
--- a/igs/bfarm/fhir-ig-installer.conf
+++ b/igs/bfarm/fhir-ig-installer.conf
@@ -1,4 +1,4 @@
 # FHIR Packages
 
 https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/tiflow/2.0.0-ballot.2/package.tgz
-https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.1/package.tgz
+https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.2/package.tgz

--- a/igs/bfarm/package.json
+++ b/igs/bfarm/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "de.gematik.ti": "1.4.0-ballot.1",
+    "de.gematik.ti": "1.4.0-ballot.2",
     "de.gematik.tiflow": "2.0.0-ballot.2"
   }
 }

--- a/igs/bfarm/sushi-config.yaml
+++ b/igs/bfarm/sushi-config.yaml
@@ -28,6 +28,7 @@ publisher:
 #
 dependencies:
   de.gematik.ti: 1.4.0-ballot.2
+  hl7.fhir.uv.xver-r5.r4: 0.1.0
 # The pages property corresponds to IG.definition.page. SUSHI can
 # auto-generate the page list, but if the author includes pages in
 # this file, it is assumed that the author will fully manage the

--- a/igs/bfarm/sushi-config.yaml
+++ b/igs/bfarm/sushi-config.yaml
@@ -27,8 +27,7 @@ publisher:
 # use cases, the value can be an object with keys for id, uri, and version.
 #
 dependencies:
-  de.gematik.ti: 1.4.0-ballot.1
-  hl7.fhir.uv.xver-r5.r4: latest
+  de.gematik.ti: 1.4.0-ballot.2
 # The pages property corresponds to IG.definition.page. SUSHI can
 # auto-generate the page list, but if the author includes pages in
 # this file, it is assumed that the author will fully manage the

--- a/igs/build-record.yaml
+++ b/igs/build-record.yaml
@@ -1,0 +1,2 @@
+versions:
+  fhirscripts: 0.30.0

--- a/igs/core/build-record.yaml
+++ b/igs/core/build-record.yaml
@@ -1,7 +1,7 @@
 versions:
   FSH Sushi: 3.20.1
   IG Publisher: 'Picked up JAVA_TOOL_OPTIONS: -Dhttp.nonProxyHosts=''localhost|gsbeel02.int.gematik.de''
-    2.2.10'
+    2.3.2'
   Java: 21.0.7
   PlantUML: 1.2025.2
   Python: 3.14.6

--- a/igs/core/fhir-ig-installer.conf
+++ b/igs/core/fhir-ig-installer.conf
@@ -1,3 +1,3 @@
 # FHIR Packages
 
-https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.1/package.tgz
+https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.2/package.tgz

--- a/igs/core/input/ignoreWarnings.txt
+++ b/igs/core/input/ignoreWarnings.txt
@@ -42,6 +42,7 @@
 %ValueSet/tiflow-audit-event-agent-type-vs should have an OID%
 %ValueSet/tiflow-operation-outcome-details-vs should have an OID assigned%
 %ValueSet/tiflow-order-task-status-vs should have an OID assigned to cater for possible%
+%could usefully have an OID assigned%
 
 # This is intended
 The slice definition for Signature.type has a maximum of 1 but the slices add up to a maximum of 2. Check that this is what is intended

--- a/igs/core/package.json
+++ b/igs/core/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "de.basisprofil.r4": "1.5.4",
+    "de.basisprofil.r4": "1.6.0",
     "de.gematik.ti": "1.4.0-ballot.2"
   }
 }

--- a/igs/core/package.json
+++ b/igs/core/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
     "de.basisprofil.r4": "1.5.4",
-    "de.gematik.ti": "1.4.0-ballot.1"
+    "de.gematik.ti": "1.4.0-ballot.2"
   }
 }

--- a/igs/core/sushi-config.yaml
+++ b/igs/core/sushi-config.yaml
@@ -19,7 +19,7 @@ publisher:
 
 dependencies:
   de.basisprofil.r4: 1.5.4
-  de.gematik.ti: 1.4.0-ballot.1
+  de.gematik.ti: 1.4.0-ballot.2
 
 menu:
   Start: index.html

--- a/igs/core/sushi-config.yaml
+++ b/igs/core/sushi-config.yaml
@@ -18,7 +18,7 @@ publisher:
   email: erp-umsetzung@gematik.de
 
 dependencies:
-  de.basisprofil.r4: 1.5.4
+  de.basisprofil.r4: 1.6.0
   de.gematik.ti: 1.4.0-ballot.2
 
 menu:

--- a/igs/diga/fhir-ig-installer.conf
+++ b/igs/diga/fhir-ig-installer.conf
@@ -1,4 +1,4 @@
 # FHIR Packages
 
-https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.1/package.tgz
+https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.2/package.tgz
 https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/tiflow/2.0.0-ballot.2/package.tgz

--- a/igs/diga/package.json
+++ b/igs/diga/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
     "de.basisprofil.r4": "1.5.4",
-    "de.gematik.ti": "1.4.0-ballot.1",
+    "de.gematik.ti": "1.4.0-ballot.2",
     "de.gematik.tiflow": "2.0.0-ballot.2"
   }
 }

--- a/igs/diga/package.json
+++ b/igs/diga/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "de.basisprofil.r4": "1.5.4",
+    "de.basisprofil.r4": "1.6.0",
     "de.gematik.ti": "1.4.0-ballot.2",
     "de.gematik.tiflow": "2.0.0-ballot.2"
   }

--- a/igs/diga/sushi-config.yaml
+++ b/igs/diga/sushi-config.yaml
@@ -17,7 +17,7 @@ publisher:
   email: erp-umsetzung@gematik.de
 
 dependencies:
-  de.basisprofil.r4: 1.5.4
+  de.basisprofil.r4: 1.6.0
   de.gematik.ti: 1.4.0-ballot.2
   de.gematik.tiflow: 2.0.0-ballot.2
 

--- a/igs/diga/sushi-config.yaml
+++ b/igs/diga/sushi-config.yaml
@@ -18,7 +18,7 @@ publisher:
 
 dependencies:
   de.basisprofil.r4: 1.5.4
-  de.gematik.ti: 1.4.0-ballot.1
+  de.gematik.ti: 1.4.0-ballot.2
   de.gematik.tiflow: 2.0.0-ballot.2
 
 menu:

--- a/igs/erp-chrg/fhir-ig-installer.conf
+++ b/igs/erp-chrg/fhir-ig-installer.conf
@@ -1,4 +1,4 @@
 # FHIR Packages
 
-https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.1/package.tgz
+https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.2/package.tgz
 https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/tiflow/2.0.0-ballot.2/package.tgz

--- a/igs/erp-chrg/package.json
+++ b/igs/erp-chrg/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "de.basisprofil.r4": "1.5.4",
+    "de.basisprofil.r4": "1.6.0",
     "de.gematik.tiflow": "2.0.0-ballot.2",
     "de.gematik.ti": "1.4.0-ballot.2"
   }

--- a/igs/erp-chrg/package.json
+++ b/igs/erp-chrg/package.json
@@ -11,6 +11,6 @@
     "hl7.fhir.r4.core": "4.0.1",
     "de.basisprofil.r4": "1.5.4",
     "de.gematik.tiflow": "2.0.0-ballot.2",
-    "de.gematik.ti": "1.4.0-ballot.1"
+    "de.gematik.ti": "1.4.0-ballot.2"
   }
 }

--- a/igs/erp-chrg/sushi-config.yaml
+++ b/igs/erp-chrg/sushi-config.yaml
@@ -18,7 +18,7 @@ publisher:
 dependencies:
   de.basisprofil.r4: 1.5.4 # Abweichung zur package.json wegen fehlender Snapshots in Version 1.5.2
   de.gematik.tiflow: 2.0.0-ballot.2
-  de.gematik.ti: 1.4.0-ballot.1
+  de.gematik.ti: 1.4.0-ballot.2
 
 menu:
   Start: index.html

--- a/igs/erp-chrg/sushi-config.yaml
+++ b/igs/erp-chrg/sushi-config.yaml
@@ -16,7 +16,7 @@ publisher:
   email: erp-umsetzung@gematik.de
 
 dependencies:
-  de.basisprofil.r4: 1.5.4 # Abweichung zur package.json wegen fehlender Snapshots in Version 1.5.2
+  de.basisprofil.r4: 1.6.0 # Abweichung zur package.json wegen fehlender Snapshots in Version 1.5.2
   de.gematik.tiflow: 2.0.0-ballot.2
   de.gematik.ti: 1.4.0-ballot.2
 

--- a/igs/rx/fhir-ig-installer.conf
+++ b/igs/rx/fhir-ig-installer.conf
@@ -1,4 +1,4 @@
 # FHIR Packages
 
-https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.1/package.tgz
+https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/ti/1.4.0-ballot.2/package.tgz
 https://storage.googleapis.com/gematik_gemspec_fhir_dev-0/ig/fhir/tiflow/2.0.0-ballot.2/package.tgz

--- a/igs/rx/input/fsh/aliases.fsh
+++ b/igs/rx/input/fsh/aliases.fsh
@@ -8,7 +8,7 @@ Alias: $erp-communication-reply = https://gematik.de/fhir/erp/StructureDefinitio
 Alias: $erp-communication-representative = https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Representative
 Alias: $erp-medication-dispense = https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense
 
-Alias: $tiflow-core-oo-cs = https://gematik.de/fhir/tiflow/core/CodeSystem/tiflow-operation-outcome-details-cs
+Alias: $tiflow-core-oo-cs = https://gematik.de/fhir/tiflow/CodeSystem/tiflow-operation-outcome-details-cs
 Alias: $ti-oo = https://gematik.de/fhir/ti/CodeSystem/operation-outcome-details-codes
 Alias: $hl7-oo = http://terminology.hl7.org/CodeSystem/operation-outcome
 

--- a/igs/rx/input/fsh/examples/Example-EU-AccessCode.fsh
+++ b/igs/rx/input/fsh/examples/Example-EU-AccessCode.fsh
@@ -12,8 +12,8 @@ Usage: #example
 Title: "GEM_ERPEU_PR_PAR_Access_Authorization_Response"
 * parameter[countryCode].valueCoding.code = #BE
 * parameter[accessCode].valueIdentifier.value = "ABC123"
-* parameter[validUntil].valueInstant = "2025-10-01T13:12:32+02:00"
-* parameter[createdAt].valueInstant = "2025-10-01T12:12:32+02:00"
+* insert DateTimeStamp(parameter[createdAt].valueInstant)
+* insert DateTimeStampPlus1Hr(parameter[validUntil].valueInstant)
 
 // Invalid Examples to Test Invariants
 

--- a/igs/rx/input/fsh/examples/Example_API_Placeholders.fsh
+++ b/igs/rx/input/fsh/examples/Example_API_Placeholders.fsh
@@ -11,6 +11,7 @@ Description: "Reusable example request payload for operation documentation in th
 * parameter[+].name = "secret"
 * parameter[=].valueString = "A1B2C3D4E5"
 
+/*
 Instance: ExampleRxOperationOutcomeError
 InstanceOf: OperationOutcome
 Usage: #example
@@ -21,6 +22,7 @@ Description: "Representative error response for invalid task status during opera
 * issue[0].code = #conflict
 * issue[0].details.text = "Task has invalid status draft"
 * issue[0].diagnostics = "Operation requires Task status ready or in-progress"
+*/
 
 Instance: ExampleRxTaskInReadyState
 InstanceOf: Task

--- a/igs/rx/input/fsh/examples/Example_API_Placeholders.fsh
+++ b/igs/rx/input/fsh/examples/Example_API_Placeholders.fsh
@@ -61,8 +61,8 @@ Description: "Example response for GET /Task"
 * total = 1
 * link[+].relation = "self"
 * link[=].url = "https://erp-ref.example.org/Task?status=ready&_count=1"
-* entry[+].fullUrl = "https://erp-ref.example.org/Task/ExampleRxTaskInReadyState"
-* entry[=].resource = ExampleRxTaskInReadyState
+* entry[+].fullUrl = "https://erp-ref.example.org/Task/TaskInReadyState"
+* entry[=].resource = TaskInReadyState
 * entry[=].search.mode = #match
 
 Instance: ExampleRxCommunicationSearchset

--- a/igs/rx/input/fsh/examples/Example_AuditEvent.fsh
+++ b/igs/rx/input/fsh/examples/Example_AuditEvent.fsh
@@ -1,3 +1,4 @@
+/*
 Instance: AuditEventSample
 InstanceOf: TIFlowAuditEventRest
 Title: "AuditEvent-Eintrag vom TI-Flow-Fachdienst"
@@ -36,3 +37,4 @@ Usage: #example
 * entity[=].type.code = #Task
 * entity[=].what.identifier.system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
 * entity[=].what.identifier.value = "160.123.456.789.123.58"
+*/

--- a/igs/rx/input/fsh/examples/Example_Binary.fsh
+++ b/igs/rx/input/fsh/examples/Example_Binary.fsh
@@ -10,6 +10,6 @@ Instance: PrescriptionBinaryWithMeta
 InstanceOf: GEM_ERP_PR_Binary
 Title: "Binary einer Verschreibung (QES) mit Metadaten"
 Description: "Beispiel für binäre Daten einer elektronischen Verschreibung mit erweiterten Metadaten"
-Usage: #inline
+Usage: #example
 * contentType = #application/pkcs7-mime
 * data = "dGhpcyBibG9iIGlzIHNuaXBwZWQ="

--- a/igs/rx/input/fsh/examples/Example_Bundle.fsh
+++ b/igs/rx/input/fsh/examples/Example_Bundle.fsh
@@ -3,7 +3,7 @@ Instance: ReceiptBundleBinary
 InstanceOf: GEM_ERP_PR_Digest
 Title: "Quittungs-Hash Binärdaten"
 Description: "Binäre Digest-Daten für ein E-Rezept-Quittungs-Bundle"
-Usage: #inline
+Usage: #example
 * id = "b939a82a-9c23-4b6d-a139-f468d1b9d652"
 * contentType = #application/octet-stream
 * data = "tJg8c5ZtdhzEEhJ0ZpAsUVFx5dKuYgQFs5oKgthi17M="
@@ -34,3 +34,36 @@ Description: "Bundle-Antwort der $accept-Operation mit Task und qualifiziert sig
 * entry[task].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/d70932d1-9e1c-483c-b2d4-b7dced09b35e"
 * entry[binary].resource = PrescriptionBinaryWithMeta
 * entry[binary].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Binary/PrescriptionBinaryWithMeta"
+
+Instance: ExampleERPBundle
+InstanceOf: Bundle
+Usage: #example
+Title: "E-Rezept-Verordnungs-Bundle (unvollständig)"
+Description: "Unvollständiges Beispiel eines E-Rezept-Bundles nach KBV_PR_EVDGA_Bundle"
+* meta.tag.display = "Unvollständiges Beispiel eines E-Rezept-Bundles - https://fhir.kbv.de/StructureDefinition/KBV_PR_EVDGA_Bundle|1.2"
+* id = "ExampleERPBundle"
+* identifier.system = $prescription-id-ns
+* identifier.value = "160.000.000.000.000.01"
+* type = #document
+* insert DateTimeStamp(timestamp)
+* entry[+].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Composition/c624cf47-e235-4624-af71-0a09dc9254dc"
+* entry[=].resource = ReceiptBundleComposition
+* entry[+].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Device/ReceiptBundleDevice"
+* entry[=].resource = ReceiptBundleDevice
+* entry[+].fullUrl = "urn:uuid:b939a82a-9c23-4b6d-a139-f468d1b9d652"
+* entry[=].resource = ReceiptBundleBinary
+
+Instance: ExampleMedicationDispenseSearchResponse
+InstanceOf: Bundle
+Usage: #example
+* type = #searchset
+* insert DateTimeStamp(timestamp)
+* total = 0
+* link.relation = "self"
+* link.url = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/MedicationDispense?identifier=160.000.000.000.000.01"
+* entry[0].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/MedicationDispense/Example-MedicationDispense"
+* entry[=].resource = Example-MedicationDispense
+* entry[=].search.mode = #match
+* entry[+].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Medication/SumatripanMedication"
+* entry[=].resource = SumatripanMedication
+* entry[=].search.mode = #include

--- a/igs/rx/input/fsh/examples/Example_Composition.fsh
+++ b/igs/rx/input/fsh/examples/Example_Composition.fsh
@@ -13,6 +13,6 @@ Usage: #inline
 * insert DateTime(date)
 * insert DateTime(event.period.start)
 * insert DateTime(event.period.end)
-* author.reference = "urn:uuid:1413b38d-81a6-432a-a801-98d7307a422b"
+* author.reference = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Device/ReceiptBundleDevice"
 * title = "Quittung"
 * section[+].entry.reference = "urn:uuid:b939a82a-9c23-4b6d-a139-f468d1b9d652"

--- a/igs/rx/input/fsh/examples/Example_Device.fsh
+++ b/igs/rx/input/fsh/examples/Example_Device.fsh
@@ -5,9 +5,9 @@ Description: "Beispiel für ein Gerät, das für die Erstellung von E-Rezept-Qui
 Usage: #example
 * id = "ReceiptBundleDevice"
 * status = #active
-* serialNumber = "1.14.0"
+* serialNumber = "2.0.0"
 * deviceName.name = "TI-Flow-Fachdienst"
 * deviceName.type = #user-friendly-name
-* version.value = "1.14.0"
+* version.value = "2.0.0"
 * contact.system = #email
 * contact.value = "betrieb@gematik.de"

--- a/igs/rx/input/fsh/examples/Example_EU_API_Placeholders.fsh
+++ b/igs/rx/input/fsh/examples/Example_EU_API_Placeholders.fsh
@@ -1,12 +1,38 @@
 // TODO: Validate and replace placeholder examples used by gematik-api blocks in pagecontent.
 
 Instance: ExampleERPEUOperationOutcomeError
-InstanceOf: OperationOutcome
+InstanceOf: TIFlowOperationOutcome
+Title: "Beispiel für Abort-Operation Fehlerantwort (412)"
+Description: "Beispiel für eine Fehlerantwort bei der Abort-Operation"
 Usage: #example
-Title: "Example error response for ERP-EU operations"
-Description: "Representative validation error for EU access operation input"
 * id = "ExampleERPEUOperationOutcomeError"
-* issue[0].severity = #error
-* issue[0].code = #invalid
-* issue[0].details.text = "countryCode is not supported"
-* issue[0].diagnostics = "Expected one of approved EU country codes in requestData.countryCode"
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_AUTH_ROLE_NOT_ALLOWED
+  * details.text = "Der Nutzer ist nicht berechtigt, die aufgerufene Operation anzufordern"
+
+Instance: ExampleERPEUTaskInReadyState
+InstanceOf: GEM_ERP_PR_Task
+Title:   "Task activated by (Z)PVS/KIS via $activate operation that carries a dispensable ePrescription"
+Usage: #example
+* meta.tag.display = "Task in READY state activated by (Z)PVS/KIS via $activate operation"
+* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#160 "Flowtype für Apothekenpflichtige Arzneimittel"
+* extension[acceptDate].valueDate = "2026-04-02"
+* extension[expiryDate].valueDate = "2026-06-02"
+* extension[eu-isRedeemableByProperties].valueBoolean = true
+* extension[eu-isRedeemableByPatientAuthorization].valueBoolean = true
+* identifier[PrescriptionID].value = "160.000.000.000.000.01"
+* identifier[AccessCode].value = "777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
+* status = #ready
+* intent = #order
+* authoredOn = "2026-03-18T15:26:00+00:00"
+* performerType[+].coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType#urn:oid:1.2.276.0.76.4.54 "Öffentliche Apotheke"
+* for.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
+* for.identifier.value = "X123456789"
+* lastModified = "2026-03-18T15:27:00+00:00"
+* input[ePrescription].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#1 "Health Care Provider Prescription"
+* input[ePrescription].valueReference = Reference(PrescriptionBinaryWithMeta)
+* input[patientReceipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#2 "Patient Confirmation"
+* input[patientReceipt].valueReference = Reference(ExampleERPBundle)

--- a/igs/rx/input/fsh/examples/Example_Quitting.fsh
+++ b/igs/rx/input/fsh/examples/Example_Quitting.fsh
@@ -11,13 +11,13 @@ Usage: #example
 * insert DateTime(timestamp)
 * entry[DocumentInformation].fullUrl = "urn:uuid:c624cf47-e235-4624-af71-0a09dc9254dc"
 * entry[DocumentInformation].resource = ReceiptBundleComposition
-* entry[SigningDevice].fullUrl = "urn:uuid:1413b38d-81a6-432a-a801-98d7307a422b"
+* entry[SigningDevice].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Device/ReceiptBundleDevice"
 * entry[SigningDevice].resource = ReceiptBundleDevice
 * entry[PrescriptionDigest].fullUrl = "urn:uuid:b939a82a-9c23-4b6d-a139-f468d1b9d652"
 * entry[PrescriptionDigest].resource = ReceiptBundleBinary
 * signature.type[AuthorsSignature].system = "urn:iso-astm:E1762-95:2013"
 * signature.type[AuthorsSignature].code = #1.2.840.10065.1.12.1.1
 * insert DateTime(signature.when)
-* signature.who.reference = "urn:uuid:1413b38d-81a6-432a-a801-98d7307a422b"
+* signature.who.reference = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Device/ReceiptBundleDevice"
 * signature.sigFormat = #application/pkcs7-mime
 * signature.data = "dGhpcyBibG9iIGlzIHNuaXBwZWQ="

--- a/igs/rx/input/fsh/examples/Example_Task.fsh
+++ b/igs/rx/input/fsh/examples/Example_Task.fsh
@@ -168,3 +168,32 @@ Usage: #example
 * input[patientReceipt].valueReference = Reference(ExampleERPBundle)
 * output[receipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#3 "Receipt"
 * output[receipt].valueReference = Reference(ReceiptBundleQuittung)
+
+
+Instance: TaskWithId
+InstanceOf: GEM_ERP_PR_Task
+Title: "Task aktiviert durch (Z)PVS/KIS via $activate Operation"
+Description: "Beispiel für einen Task, der durch (Z)PVS/KIS über die $activate Operation aktiviert wurde und ein einlösbares E-Rezept trägt"
+Usage: #example
+* id = "160.000.033.491.280.78"
+* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
+* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#160 "Flowtype für Apothekenpflichtige Arzneimittel"
+* extension[acceptDate].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate"
+* insert Date(extension[acceptDate].valueDate)
+* extension[expiryDate].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate"
+* insert Date(extension[expiryDate].valueDate)
+* identifier[PrescriptionID].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier[PrescriptionID].value = "160.000.033.491.280.78"
+* identifier[AccessCode].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_AccessCode"
+* identifier[AccessCode].value = "777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
+* status = #ready
+* intent = #order
+* insert DateTime(authoredOn)
+* performerType[+].coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType#urn:oid:1.2.276.0.76.4.54 "Öffentliche Apotheke"
+* for.identifier.system = $identifier-kvid-10
+* for.identifier.value = "X123456789"
+* insert DateTimeStampPlus1Hr(lastModified)
+* input[ePrescription].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#1 "Health Care Provider Prescription"
+* input[ePrescription].valueReference = Reference(PrescriptionBinaryWithMeta)
+* input[patientReceipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#2 "Patient Confirmation"
+* input[patientReceipt].valueReference = Reference(ExampleERPBundle)

--- a/igs/rx/input/fsh/examples/Example_Task.fsh
+++ b/igs/rx/input/fsh/examples/Example_Task.fsh
@@ -4,7 +4,7 @@ InstanceOf: GEM_ERP_PR_Task
 Title: "Task erstellt durch Fachdienst via $create Operation"
 Description: "Beispiel für einen Task, der vom Fachdienst über die $create Operation erstellt wurde"
 Usage: #example
-* id = "b12eb5f7-91ce-4887-93c7-800454601377"
+* id = "TaskInCreatedState"
 * meta.tag.display = "Task in DRAFT state just created by Fachdienst via $create operation"
 * extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
 * extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#160 "Flowtype für Apothekenpflichtige Arzneimittel"
@@ -46,9 +46,9 @@ Usage: #example
 * for.identifier.value = "X123456789"
 * insert DateTimeStampPlus1Hr(lastModified)
 * input[ePrescription].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#1 "Health Care Provider Prescription"
-* input[ePrescription].valueReference.reference = "281a985c-f25b-4aae-91a6-41ad744080b0"
+* input[ePrescription].valueReference = Reference(PrescriptionBinaryWithMeta)
 * input[patientReceipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#2 "Patient Confirmation"
-* input[patientReceipt].valueReference.reference = "f8c2298f-7c00-4a68-af29-8a2862d55d43"
+* input[patientReceipt].valueReference = Reference(ExampleERPBundle)
 
 Instance: TaskIn-ProgressState
 InstanceOf: GEM_ERP_PR_Task

--- a/igs/rx/input/fsh/examples/Example_Task.fsh
+++ b/igs/rx/input/fsh/examples/Example_Task.fsh
@@ -75,7 +75,7 @@ Usage: #example
 * for.identifier.value = "X123456789"
 * insert DateTimeStampPlus1Hr(lastModified)
 * input[ePrescription].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#1 "Health Care Provider Prescription"
-* input[ePrescription].valueReference = Reference(PrescriptionBinary)
+* input[ePrescription].valueReference = Reference(PrescriptionBinaryWithMeta)
 
 Instance: TaskIn-ProgressState-Dispensed
 InstanceOf: GEM_ERP_PR_Task
@@ -103,9 +103,9 @@ Usage: #example
 * for.identifier.value = "X123456789"
 * insert DateTimeStampPlus1Hr(lastModified)
 * input[ePrescription].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#1 "Health Care Provider Prescription"
-* input[ePrescription].valueReference.reference = "281a985c-f25b-4aae-91a6-41ad744080b0"
+* input[ePrescription].valueReference = Reference(PrescriptionBinaryWithMeta)
 * input[patientReceipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#2 "Patient Confirmation"
-* input[patientReceipt].valueReference.reference = "f8c2298f-7c00-4a68-af29-8a2862d55d43"
+* input[patientReceipt].valueReference = Reference(ExampleERPBundle)
 
 Instance: TaskIn-ProgressState-Dispensed-Multiple-MedicationDispenses
 InstanceOf: GEM_ERP_PR_Task
@@ -134,9 +134,9 @@ Usage: #example
 * for.identifier.value = "X123456789"
 * insert DateTimeStampPlus1Hr(lastModified)
 * input[ePrescription].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#1 "Health Care Provider Prescription"
-* input[ePrescription].valueReference.reference = "281a985c-f25b-4aae-91a6-41ad744080b0"
+* input[ePrescription].valueReference = Reference(PrescriptionBinaryWithMeta)
 * input[patientReceipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#2 "Patient Confirmation"
-* input[patientReceipt].valueReference.reference = "f8c2298f-7c00-4a68-af29-8a2862d55d43"
+* input[patientReceipt].valueReference = Reference(ExampleERPBundle)
 
 Instance: TaskInClosedState
 InstanceOf: GEM_ERP_PR_Task
@@ -163,8 +163,8 @@ Usage: #example
 * for.identifier.value = "X123456789"
 * insert DateTimeStampPlus1Hr(lastModified)
 * input[ePrescription].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#1 "Health Care Provider Prescription"
-* input[ePrescription].valueReference.reference = "281a985c-f25b-4aae-91a6-41ad744080b0"
+* input[ePrescription].valueReference = Reference(PrescriptionBinaryWithMeta)
 * input[patientReceipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#2 "Patient Confirmation"
-* input[patientReceipt].valueReference.reference = "f8c2298f-7c00-4a68-af29-8a2862d55d43"
+* input[patientReceipt].valueReference = Reference(ExampleERPBundle)
 * output[receipt].type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#3 "Receipt"
-* output[receipt].valueReference.reference = "dffbfd6a-5712-4798-bdc8-07201eb77ab8"
+* output[receipt].valueReference = Reference(ReceiptBundleQuittung)

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Abort.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Abort.fsh
@@ -1,0 +1,36 @@
+Instance: ExampleOperationAbortErrorAVS
+InstanceOf: TIFlowOperationOutcome
+Title: "Beispiel für Abort-Operation Fehlerantwort (403)"
+Description: "Beispiel für eine Fehlerantwort bei der Abort-Operation"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #forbidden
+  * details.coding.system = $ti-oo
+  * details.coding.code = #SVC_IDENTITY_MISMATCH
+  * details.text = "Identity mismatch: Access token or x-insurantid header does not match FHIR data (Telematik-ID / KVNR)"
+
+Instance: ExampleOperationAbortErrorPVS
+InstanceOf: TIFlowOperationOutcome
+Title: "Beispiel für Abort-Operation Fehlerantwort (412)"
+Description: "Beispiel für eine Fehlerantwort bei der Abort-Operation"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #forbidden
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_TASK_STATUS_MISMATCH
+  * details.text = "Task has invalid status."
+
+  
+Instance: ExampleOperationAbortErrorRoleFdV
+InstanceOf: TIFlowOperationOutcome
+Title: "Fehler 403 - Beispiel für Abort-Operation Fehlerantwort bei Rollenprüfung"
+Description: "Beispiel für eine Fehlerantwort bei der Abort-Operation bei Rollenprüfung"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_AUTH_ROLE_NOT_ALLOWED
+  * details.text = "Der Nutzer ist nicht berechtigt, die aufgerufene Operation anzufordern"

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Accept.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Accept.fsh
@@ -1,0 +1,37 @@
+Instance: ExampleOperationAcceptError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 409 - Beispiel für Accept-Operation Fehlerantwort"
+Description: "Beispiel für eine Fehlerantwort bei der Accept-Operation eines E-Rezepts"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_TASK_STATUS_MISMATCH
+  * details.text = "Task has invalid status draft"
+
+Instance: ExampleOperationAcceptRoleError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 403 - Beispiel für Accept-Operation durch Rollenprüfung"
+Description: "Beispiel für eine Fehlerantwort Rollenprüfung bei der Accept-Operation eines E-Rezepts"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_AUTH_ROLE_NOT_ALLOWED
+  * details.text = "Der Nutzer ist nicht berechtigt, die aufgerufene Operation anzufordern"
+
+Instance: ExampleRXAcceptResponse
+InstanceOf: Bundle
+Usage: #example
+Title: "$accept response for RX"
+Description: "Example response for $accept in RX workflow"
+* id = "ExampleRXAcceptResponse"
+* type = #collection
+* link[+].relation = "self"
+* link[=].url = "https://erp-ref.example.org/Task/162.000.000.000.000.01/$accept"
+* entry[+].fullUrl = "https://erp-ref.example.org/Task/TaskInReadyState"
+* entry[=].resource = TaskInReadyState
+* entry[+].fullUrl = "https://erp-ref.example.org/Binary/PrescriptionBinaryWithMeta"
+* entry[=].resource = PrescriptionBinaryWithMeta

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Activate.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Activate.fsh
@@ -1,0 +1,31 @@
+Instance: ExampleOperationActivateParametersInput
+InstanceOf: Parameters
+Title: "Example Activate operation input parameters"
+Description: "Beispiel der Eingabeparameter für die $activate-Operation im RX-Workflow"
+Usage: #example
+* parameter[+].name = "ePrescription"
+* parameter[=].resource = PrescriptionBinaryWithMeta
+
+Instance: ExampleOperationActivateInvalidRoleError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 400 - QES nicht valide; Example Activate operation error response"
+Description: "Beispiel einer Fehlerantwort der $activate-Operation bei ungültiger Signatur"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_SIGNATURE_INVALID
+
+Instance: ExampleOperationActivateError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 400 - Example Activate operation error response"
+Description: "Beispiel einer Fehlerantwort der $activate-Operation bei fehlgeschlagener Profilvalidierung"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $ti-oo
+  * details.coding.code = #SVC_VALIDATION_FAILED
+  * details.text = "FHIR Profile Validation Failed"
+  * diagnostics = "Unable to determine profile type from name: https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Bundle"

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Close.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Close.fsh
@@ -1,0 +1,106 @@
+Instance: ExampleOperationCloseError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 400 - Beispiel für Close-Operation Fehlerantwort"
+Description: "Beispiel für eine Fehlerantwort bei der Close-Operation mit FHIR-Validierungsfehlern"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $ti-oo
+  * details.coding.code = #SVC_VALIDATION_FAILED
+  * details.text = "FHIR Profile Validation Failed"
+  
+Instance: ExampleOperationCloseProfileError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 400 - Beispiel für Close-Operation Fehlerantwort bei Profilprüfung MedicationDispense"
+Description: "Beispiel für eine Fehlerantwort bei der Close-Operation mit Profilprüfung MedicationDispense"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_MEDICATION_DISPENSE_INVALID
+  * details.text = "Unzulässige Abgabeinformationen: Für diesen Workflow sind nur Abgabeinformationen für digitale Gesundheitsanwendungen zulässig."
+
+/*
+Instance: ExampleCloseInputParameters
+InstanceOf: GEM_ERP_PR_PAR_CloseOperation_Input 
+Usage: #example
+Title: "Example Close Parameters"
+Description: "Beispiel der Eingabeparameter für die $close-Operation im ERP-Workflow"
+* parameter[+]
+  * name = "rxDispensation"
+  * part[+] //TODO: Named Slices
+    * name = "medicationDispense"
+    * resource = Example-MedicationDispense-Dosage-tageszeit
+*/
+
+Instance: ExampleCloseOutputParameters
+InstanceOf: GEM_ERP_PR_PAR_CloseOperation_Output
+Usage: #example
+Title: "Example Close Parameters"
+Description: "Beispiel der Ausgabeparameter der $close-Operation im ERP-Workflow"
+* parameter[+]
+  * name = "return"
+  * resource = ReceiptBundleQuittung 
+
+/*
+Instance: ExampleOperationCloseOutput
+InstanceOf: TIFlowDiGAReceiptBundle
+Title: "Quittungs-Bundle für abgeschlossene Rezeptabgabe"
+Description: "Beispiel für ein Quittungs-Bundle nach erfolgter Abgabe einer DiGA"
+Usage: #example
+//* id = "dffbfd6a-5712-4798-bdc8-07201eb77ab8"
+* meta.tag.display = "Receipt Bundle 'Quittung' for completed dispensation of a prescription"
+* identifier[+].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier[=].value = "162.000.033.491.280.78"
+* type = #document
+* insert DateTime(timestamp)
+* entry[DocumentInformation].fullUrl = "urn:uuid:c624cf47-e235-4624-af71-0a09dc9254dc"
+* entry[DocumentInformation].resource = ReceiptBundleComposition
+* entry[SigningDevice].fullUrl = "urn:uuid:1413b38d-81a6-432a-a801-98d7307a422b"
+* entry[SigningDevice].resource = ReceiptBundleDevice
+* entry[PrescriptionDigest].fullUrl = "urn:uuid:b939a82a-9c23-4b6d-a139-f468d1b9d652"
+* entry[PrescriptionDigest].resource = ReceiptBundleBinary
+* signature.type[AuthorsSignature].system = "urn:iso-astm:E1762-95:2013"
+* signature.type[AuthorsSignature].code = #1.2.840.10065.1.12.1.1
+* insert DateTime(signature.when)
+* signature.who.reference = "urn:uuid:1413b38d-81a6-432a-a801-98d7307a422b"
+* signature.sigFormat = #application/pkcs7-mime
+* signature.data = "dGhpcyBibG9iIGlzIHNuaXBwZWQ="
+*/
+
+/*
+Instance: ReceiptBundleComposition
+InstanceOf: TIFlowDiGAReceiptComposition
+Title: "Zusammenstellung für Quittungs-Bundle"
+Description: "Beispiel für eine Zusammenstellung (Composition) für ein DiGA-Quittungs-Bundle"
+Usage: #inline
+* id = "c624cf47-e235-4624-af71-0a09dc9254dc"
+* extension[Beneficiary].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_Beneficiary"
+* extension[Beneficiary].valueIdentifier.system = $identifier-telematik-id
+* extension[Beneficiary].valueIdentifier.value = "8-SMC-B-Testkarte-883110000129070"
+* status = #final
+* type.coding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType#3 "Receipt"
+* insert DateTime(date)
+* insert DateTime(event.period.start)
+* insert DateTime(event.period.end)
+* author.reference = "urn:uuid:1413b38d-81a6-432a-a801-98d7307a422b"
+* title = "Quittung"
+* section[+].entry.reference = "urn:uuid:b939a82a-9c23-4b6d-a139-f468d1b9d652"
+*/
+
+/*Instance: ExampleReceiptBundle
+InstanceOf: TIFlowDiGAReceiptBundle
+Title: "Quittungs-Bundle für abgeschlossene Rezeptabgabe"
+Description: "Beispiel für ein Quittungs-Bundle nach erfolgter Abgabe einer DiGA"
+Usage: #inline
+* id = "ExampleReceiptBundle"
+* type = #document
+* identifier[+].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier[=].value = "162.000.033.491.280.78"
+* insert DateTime(timestamp)
+* entry[+].fullUrl = "urn:uuid:1413b38d-81a6-432a-a801-98d7307a422b"
+* entry[=].resource = ReceiptBundleDevice
+* entry[+].fullUrl = "urn:uuid:b939a82a-9c23-4b6d-a139-f468d1b9d652"
+* entry[=].resource = ReceiptBundleBinary*/

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Create.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Create.fsh
@@ -1,0 +1,39 @@
+Instance: OperationCreateParametersInputExample
+InstanceOf: Parameters
+Title: "Beispiel für $create Operation Parameter"
+Description: "Beispiel für Eingabeparameter der $create Operation zur Erstellung einer neuen Aufgabe"
+Usage: #example
+* parameter[+].name = "workflowType"
+* parameter[=].valueCoding = GEM_ERP_CS_FlowType#162
+
+Instance: ExampleCreateOperationOutputError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 403 - Beispiel für Create-Operation Fehlerantwort"
+Description: "Beispiel für eine Fehlerantwort bei der Create-Operation mit FHIR-Validierungsfehlern"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #forbidden
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_AUTH_ROLE_NOT_ALLOWED
+  * details.text = "Der Nutzer ist nicht berechtigt, die aufgerufene Operation anzufordern"
+
+Instance: ExampleOperationCreateError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 400 - Beispiel für Create-Operation Fehlerantwort"
+Description: "Beispiel für eine Fehlerantwort bei der Create-Operation mit FHIR-Validierungsfehlern"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $ti-oo
+  * details.coding.code = #SVC_VALIDATION_FAILED
+  * details.text = "FHIR Profile Validation Failed"
+  * diagnostics = """
+    Parameters.parameter[0].valueCoding: error: Code 140 is not part of CodeSystem 
+    https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType (from profile: 
+    http://hl7.org/fhir/StructureDefinition/Parameters|4.0.1); 
+    Parameters.parameter[0].valueCoding: error: Code 140 is not part of CodeSystem 
+    https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType (from profile: 
+    http://hl7.org/fhir/StructureDefinition/Coding|4.0.1);
+    """

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Dispense.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Dispense.fsh
@@ -1,0 +1,11 @@
+Instance: ExampleOperationDispenseRoleError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 403 - Beispiel für Dispense-Operation durch Rollenprüfung"
+Description: "Beispiel für eine Fehlerantwort Rollenprüfung bei der Dispense-Operation eines E-Rezepts"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_AUTH_ROLE_NOT_ALLOWED
+  * details.text = "Der Nutzer ist nicht berechtigt, die aufgerufene Operation anzufordern"

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_EU_Close.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_EU_Close.fsh
@@ -1,0 +1,11 @@
+Instance: ExampleOperationEUCloseError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 400 - Example EU Close operation error response"
+Description: "Beispiel einer Fehlerantwort der $eu-close-Operation bei fehlgeschlagener Profilvalidierung"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $ti-oo
+  * details.coding.code = #SVC_VALIDATION_FAILED
+  * details.text = "FHIR Profile Validation Failed"

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_GET_EU_Prescriptions.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_GET_EU_Prescriptions.fsh
@@ -1,0 +1,22 @@
+Instance: ExampleGetEUPrescriptionBundle
+InstanceOf: Bundle
+Usage: #example
+* insert DateTimeStamp(timestamp)
+* type = #collection
+* link[+]
+  * relation = "self"
+  * url = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Prescription"
+* entry[0].fullUrl = "https://erp.zentral.erp.splitdns.ti-dienste.de/Bundle/ExampleERPBundle"
+* entry[=].resource = ExampleERPBundle
+
+Instance: ExampleOperationGetEUError
+InstanceOf: TIFlowOperationOutcome
+Title: "Error 400 - Example EU Get Prescriptions operation error response"
+Description: "Beispiel einer Fehlerantwort der $get-eu-prescriptions-Operation bei fehlgeschlagener Profilvalidierung"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $ti-oo
+  * details.coding.code = #SVC_VALIDATION_FAILED
+  * details.text = "FHIR Profile Validation Failed"

--- a/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Reject.fsh
+++ b/igs/rx/input/fsh/examples/operation_examples/Example_Operation_Reject.fsh
@@ -1,0 +1,23 @@
+Instance: ExampleOperationRejectError
+InstanceOf: TIFlowOperationOutcome
+Title: "Fehler 412 - Beispiel für Reject-Operation Fehlerantwort"
+Description: "Beispiel für eine Fehlerantwort bei der Reject-Operation wegen falschen Task-Status"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_TASK_STATUS_MISMATCH
+  * details.text = "Task has invalid status."
+
+ Instance: ExampleOperationRejectRolleError
+InstanceOf: TIFlowOperationOutcome
+Title: "Fehler 403 - Beispiel für Reject-Operation Fehlerantwort bei Rollenprüfung"
+Description: "Beispiel für eine Fehlerantwort bei der Reject-Operation bei Rollenprüfung"
+Usage: #example
+* issue[+]
+  * severity = #error
+  * code = #invalid
+  * details.coding.system = $tiflow-core-oo-cs
+  * details.coding.code = #TIFLOW_AUTH_ROLE_NOT_ALLOWED
+  * details.text = "Der Nutzer ist nicht berechtigt, die aufgerufene Operation anzufordern"

--- a/igs/rx/input/fsh/examples/query_examples/Example_Query_API.fsh
+++ b/igs/rx/input/fsh/examples/query_examples/Example_Query_API.fsh
@@ -1,3 +1,4 @@
+/*
 Instance: GenericTask
 InstanceOf: GEM_ERP_PR_Task
 Title: "Task erstellt durch Fachdienst via $create Operation"
@@ -12,8 +13,9 @@ Usage: #example
 * status = #draft
 * intent = #order
 * insert DateTime(authoredOn)
+*/
 
-
+/*
 Instance: QueryTaskSearchResponseBundle
 InstanceOf: Bundle
 Usage: #example
@@ -26,7 +28,9 @@ Description: "Beispiel fuer eine Task-Suchantwort mit zwei Treffern"
 * link[=].url = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task?status=ready&_count=2"
 * entry[+].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/b12eb5f7-91ce-4887-93c7-800454601377"
 * entry[=].resource = GenericTask
+*/
 
+/*
 Instance: QueryAuditEventSearchResponseBundle
 InstanceOf: Bundle
 Usage: #example
@@ -39,6 +43,7 @@ Description: "Beispiel fuer eine AuditEvent-Suchantwort"
 * link[=].url = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/AuditEvent?date=ge2025-01-01"
 * entry[+].fullUrl = "https://erp-ref.zentral.erp.splitdns.ti-dienste.de/AuditEvent/9361863d-fec0-4ba9-8776-7905cf1b0cfa"
 * entry[=].resource = AuditEventSample
+*/
 
 Instance: QueryMedicationDispenseSearchResponseBundle
 InstanceOf: Bundle

--- a/igs/rx/input/fsh/examples/query_examples/Example_Query_API.fsh
+++ b/igs/rx/input/fsh/examples/query_examples/Example_Query_API.fsh
@@ -66,7 +66,7 @@ Description: "Beispiel einer Consent-Ressource fuer die Consent-Query"
 * id = "QueryConsentCHARGCONS"
 * status = #active
 * scope = http://terminology.hl7.org/CodeSystem/consentscope#patient-privacy "Privacy Consent"
-* category[+] = http://loinc.org#59284-0 "Consent Document"
+* category[+] = http://loinc.org#59284-0 "Einwilligung - Dokument"
 * patient.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
 * patient.identifier.value = "X123456789"
 * dateTime = "2025-01-15T10:15:00+01:00"

--- a/igs/rx/input/fsh/profiles/GEM_ERP_PR_Task.fsh
+++ b/igs/rx/input/fsh/profiles/GEM_ERP_PR_Task.fsh
@@ -46,7 +46,7 @@ and GEM_ERP_EX_EU_IS_REDEEMABLE_BY_PATIENT_AUTHORIZATION named eu-isRedeemableBy
     * code 1..1
     * code = #1 (exactly)
 
-// ePriscription for the patient
+// ePrescription for the patient
 * input[patientReceipt] 0..1 MS
   * ^short = "JSON-Bundle der Verordnung, das von einem FdV konsumiert werden soll"
   * value[x] only Reference(Bundle)

--- a/igs/rx/input/ignoreWarnings.txt
+++ b/igs/rx/input/ignoreWarnings.txt
@@ -95,6 +95,16 @@
 %https://gematik.de/fhir/directory/CodeSystem/OrganizationProfessionOID%
 %https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_KBV_NORMGROESSE%
 %https://gematik.de/fhir/terminology/ValueSet/ti-medication-dispense-category-vs%
+%Regel eld-20 fehlgeschlagen%
+%The contained resource matched more than one of the allowed profiles%
+%Es wurden mehrere passende Profile unter den Auswahlmöglichkeiten gefunden%
+%https://gematik.de/fhir/terminology/ValueSet/ti-medication-type-product-vs%
+%https://gematik.de/fhir/terminology/ValueSet/ti-medication-type-pharmaceutical-product-vs%
+%Das CodeSystem https://gematik.de/fhir/directory/CodeSystem/Origin ist unbekannt%
+%https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication%
+%https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request%
+%https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory%
+%https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory%
 
 
 # No Examples

--- a/igs/rx/input/ignoreWarnings.txt
+++ b/igs/rx/input/ignoreWarnings.txt
@@ -70,6 +70,8 @@
 %StructureMap/KBVPrForPractitionerMap could usefully have an OID assigned%
 %this is not in the parameters list in the operation definition%
 %Abgleich gegen Profilhttp://hl7.org/fhir/StructureDefinition/Medication|4.0.1%
+%application/pkcs7-mime%
+%https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType%
 
 # Not resolvable
 %http://fhir.org/packages/de.basisprofil.r4/ImplementationGuide/de.basisprofil.r4%

--- a/igs/rx/input/pagecontent/op-abort.md
+++ b/igs/rx/input/pagecontent/op-abort.md
@@ -28,17 +28,14 @@ Die Nachricht wird als HTTP `POST` an `/Task/{id}/$abort` gesendet.
 			{% include OperationDefinition-tiflow-rx-abort-op.json %}
 		</pre>
 	</div>
-<!--
-	<div id="Request-Examples">
-	</div>
--->
-<!--
 	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleRxOperationOutcomeError XML %}
+		<div data-name="Fehler 403 - Beispiel für Abort-Operation Fehlerantwort application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationAbortErrorRoleFdV JSON %}
+		</div>
+		<div data-name="Fehler 403 - Beispiel für Abort-Operation Fehlerantwort application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationAbortErrorRoleFdV XML %}
 		</div>
 	</div>
--->
 </div>
 
 ### Hinweise

--- a/igs/rx/input/pagecontent/op-accept.md
+++ b/igs/rx/input/pagecontent/op-accept.md
@@ -26,13 +26,26 @@ Die Nachricht wird als HTTP `POST` an `/Task/{id}/$accept` gesendet.
 			{% include OperationDefinition-tiflow-rx-accept-op.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleRxOperationOutcomeError XML %}
+		<div data-name="200 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Bundle/ExampleRXAcceptResponse XML %}
 		</div>
+		<div data-name="403 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationAcceptRoleError XML %}
+		</div>
+		<div data-name="409 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationAcceptError XML %}
+		</div>
+		<div data-name="200 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Bundle/ExampleRXAcceptResponse JSON %}
+		</div>
+		<div data-name="403 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationAcceptRoleError JSON %}
+		</div>
+		<div data-name="409 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationAcceptError JSON %}
+		</div>	
 	</div>
--->
 </div>
 
 ### Hinweise

--- a/igs/rx/input/pagecontent/op-activate.md
+++ b/igs/rx/input/pagecontent/op-activate.md
@@ -26,20 +26,34 @@ Die Nachricht wird als HTTP `POST` an `/Task/{id}/$activate` gesendet.
 			{% include OperationDefinition-tiflow-rx-activate-op.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Request-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Parameters/ExampleRxOperationRequestParameters XML %}
+			{% fragment Parameters/ExampleOperationActivateParametersInput XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleOperationActivateParametersInput JSON %}
 		</div>
 	</div>
--->
-<!--
 	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleRxOperationOutcomeError XML %}
+		<div data-name="200 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Task/TaskInReadyState XML %}
+		</div>
+		<div data-name="400 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationActivateInvalidRoleError XML %}
+		</div>
+		<div data-name="400 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationActivateError XML %}
+		</div>
+		<div data-name="200 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Task/TaskInReadyState JSON %}
+		</div>
+		<div data-name="400 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationActivateInvalidRoleError JSON %}
+		</div>
+		<div data-name="400 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationActivateError JSON %}
 		</div>
 	</div>
--->
 </div>
 
 

--- a/igs/rx/input/pagecontent/op-close.md
+++ b/igs/rx/input/pagecontent/op-close.md
@@ -26,20 +26,34 @@ Die Nachricht wird als HTTP `POST` an `/Task/{id}/$close` gesendet.
 			{% include OperationDefinition-tiflow-rx-close-op.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Request-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Parameters/ExampleRxOperationRequestParameters XML %}
+			{% fragment Parameters/ExampleCloseInputParameters XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleCloseInputParameters JSON %}
 		</div>
 	</div>
--->
-<!--
 	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleRxOperationOutcomeError XML %}
+		<div data-name="200 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleCloseOutputParameters XML %}
+		</div>
+		<div data-name="400 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationCloseError XML %}
+		</div>
+		<div data-name="400 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationCloseProfileError XML %}
+		</div>
+		<div data-name="200 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleCloseOutputParameters JSON %}
+		</div>
+		<div data-name="400 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationCloseError JSON %}
+		</div>
+		<div data-name="400 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationCloseProfileError JSON %}
 		</div>
 	</div>
--->
 </div>
 
 ### Hinweise

--- a/igs/rx/input/pagecontent/op-create.md
+++ b/igs/rx/input/pagecontent/op-create.md
@@ -29,23 +29,40 @@ Die API-Beschreibung für den Aufruf der Operation findet sich auf:
       {% include OperationDefinition-tiflow-rx-create-op.json %}
     </pre>
   </div>
-<!--
   <div id="Request-Examples">
     <div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-      {% fragment Parameters/ExampleRxOperationRequestParameters XML %}
-    </div>
+			{% fragment Parameters/OperationCreateParametersInputExample XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/OperationCreateParametersInputExample JSON %}
+		</div>
   </div>
--->
-<!--
   <div id="Response-Examples">
-    <div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-      {% fragment Task/ExampleRxTaskInReadyState XML %}
-    </div>
-    <div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-      {% fragment OperationOutcome/ExampleRxOperationOutcomeError XML %}
-    </div>
+    <pre>
+			POST /Task/$create HTTP/1.1
+			Host: example.org
+			Content-Type: application/fhir+xml; charset=UTF-8
+			Accept: application/fhir+xml
+		</pre>
+		<div data-name="200 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Task/TaskInCreatedState XML %}
+		</div>
+		<div data-name="400 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationCreateError XML %}
+		</div>
+		<div data-name="403 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleCreateOperationOutputError XML %}
+		</div>
+		<div data-name="200 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Task/TaskInCreatedState JSON %}
+		</div>
+		<div data-name="400 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationCreateError JSON %}
+		</div>
+		<div data-name="403 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleCreateOperationOutputError JSON %}
+		</div>
   </div>
--->
 </div>
 
 ### Hinweise

--- a/igs/rx/input/pagecontent/op-dispense.md
+++ b/igs/rx/input/pagecontent/op-dispense.md
@@ -25,20 +25,22 @@ Die Nachricht wird als HTTP `POST` an `/Task/{id}/$dispense` gesendet.
 			{% include OperationDefinition-tiflow-rx-dispense-op.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Request-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Parameters/ExampleRxOperationRequestParameters XML %}
+			{% fragment Parameters/ExampleDispenseInputParameters XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleDispenseInputParameters JSON %}
 		</div>
 	</div>
--->
-<!--
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleRxOperationOutcomeError XML %}
+			{% fragment OperationOutcome/ExampleOperationDispenseRoleError XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationDispenseRoleError JSON %}
 		</div>
 	</div>
--->
 </div>
 
 ### Hinweise

--- a/igs/rx/input/pagecontent/op-eu-close.md
+++ b/igs/rx/input/pagecontent/op-eu-close.md
@@ -26,20 +26,22 @@ Die Nachricht wird als HTTP `POST` an `/Task/$eu-close` gesendet.
 			{% include OperationDefinition-EUCloseOperation.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Request-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment Parameters/ExampleEUCloseInputParameters XML %}
 		</div>
-	</div>
--->
-<!--
-	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleERPEUOperationOutcomeError XML %}
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleEUCloseInputParameters JSON %}
 		</div>
 	</div>
--->
+	<div id="Response-Examples">
+		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationEUCloseError XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationEUCloseError JSON %}
+		</div>
+	</div>
 </div>
 
 

--- a/igs/rx/input/pagecontent/op-get-eu-prescriptions.md
+++ b/igs/rx/input/pagecontent/op-get-eu-prescriptions.md
@@ -26,20 +26,40 @@ Die Nachricht wird als HTTP `POST` an `/$get-eu-prescriptions` gesendet.
 			{% include OperationDefinition-GETPrescriptionEU.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Request-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+		<div data-name="Prescriptions-Retrieval - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment Parameters/ExampleEUGETPrescriptionE-PRESCRIPTIONS-RETRIEVAL XML %}
 		</div>
-	</div>
--->
-<!--
-	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleERPEUOperationOutcomeError XML %}
+		<div data-name="Prescriptions-Retrieval - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleEUGETPrescriptionE-PRESCRIPTIONS-RETRIEVAL JSON %}
+		</div>
+		<div data-name="Prescriptions-List - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleEUGETPrescriptionE-PRESCRIPTIONS-LIST XML %}
+		</div>
+		<div data-name="Prescriptions-List - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleEUGETPrescriptionE-PRESCRIPTIONS-LIST JSON %}
+		</div>
+		<div data-name="Prescriptions-Demographics - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleEUGETPrescriptionDEMOGRAPHICS XML %}
+		</div>
+		<div data-name="Prescriptions-Demographics - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/ExampleEUGETPrescriptionDEMOGRAPHICS JSON %}
 		</div>
 	</div>
--->
+	<div id="Response-Examples">
+		<div data-name="200 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Bundle/ExampleGetEUPrescriptionBundle XML %}
+		</div>
+		<div data-name="200 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Bundle/ExampleGetEUPrescriptionBundle JSON %}
+		</div>
+		<div data-name="400 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationGetEUError XML %}
+		</div>
+		<div data-name="400 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationGetEUError JSON %}
+		</div>
+	</div>
 </div>
 
 

--- a/igs/rx/input/pagecontent/op-grant-eu-access-permission.md
+++ b/igs/rx/input/pagecontent/op-grant-eu-access-permission.md
@@ -26,23 +26,28 @@ Die Nachricht wird als HTTP `POST` an `/$grant-eu-access-permission` gesendet.
 			{% include OperationDefinition-GrantEUAccessPermission.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Request-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment Parameters/Example-EU-PermissionRequest XML %}
 		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/Example-EU-PermissionRequest JSON %}
+		</div>
 	</div>
--->
-<!--
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment Parameters/Example-EU-PermissionResponse XML %}
 		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/Example-EU-PermissionResponse JSON %}
+		</div>
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment OperationOutcome/ExampleERPEUOperationOutcomeError XML %}
 		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleERPEUOperationOutcomeError JSON %}
+		</div>
 	</div>
--->
 </div>
 
 

--- a/igs/rx/input/pagecontent/op-read-eu-access-permission.md
+++ b/igs/rx/input/pagecontent/op-read-eu-access-permission.md
@@ -26,23 +26,20 @@ Die Nachricht wird als HTTP `GET` an `/$read-eu-access-permission` gesendet.
 			{% include OperationDefinition-ReadEUAccessPermission.json %}
 		</pre>
 	</div>
-<!--
-	<div id="Request-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Parameters/Example-EU-PermissionRequest XML %}
-		</div>
-	</div>
--->
-<!--
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment Parameters/Example-EU-PermissionResponse XML %}
 		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/Example-EU-PermissionResponse JSON %}
+		</div>
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment OperationOutcome/ExampleERPEUOperationOutcomeError XML %}
 		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleERPEUOperationOutcomeError JSON %}
+		</div>
 	</div>
--->
 </div>
 
 

--- a/igs/rx/input/pagecontent/op-reject.md
+++ b/igs/rx/input/pagecontent/op-reject.md
@@ -25,13 +25,20 @@ Die Nachricht wird als HTTP `POST` an `/Task/{id}/$reject` gesendet.
 			{% include OperationDefinition-tiflow-rx-reject-op.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleRxOperationOutcomeError XML %}
+		<div data-name="Fehler 403 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationRejectRolleError XML %}
+		</div>
+		<div data-name="Fehler 412 - application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationRejectError XML %}
+		</div>
+		<div data-name="Fehler 403 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationRejectRolleError JSON %}
+		</div>
+		<div data-name="Fehler 412 - application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment OperationOutcome/ExampleOperationRejectError JSON %}
 		</div>
 	</div>
--->
 </div>
 
 ### Hinweise

--- a/igs/rx/input/pagecontent/op-revoke-eu-access-permission.md
+++ b/igs/rx/input/pagecontent/op-revoke-eu-access-permission.md
@@ -26,23 +26,6 @@ Die Nachricht wird als HTTP `DELETE` an `/$revoke-eu-access-permission` gesendet
 			{% include OperationDefinition-RevokeEUAccessPermission.json %}
 		</pre>
 	</div>
-<!--
-	<div id="Request-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Parameters/Example-EU-PermissionRequest XML %}
-		</div>
-	</div>
--->
-<!--
-	<div id="Response-Examples">
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Parameters/Example-EU-PermissionResponse XML %}
-		</div>
-		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment OperationOutcome/ExampleERPEUOperationOutcomeError XML %}
-		</div>
-	</div>
--->
 </div>
 
 

--- a/igs/rx/input/pagecontent/query-api-medicationdispense.md
+++ b/igs/rx/input/pagecontent/query-api-medicationdispense.md
@@ -26,13 +26,14 @@ Anfragen an die <i>MedicationDispense</i>-Ressource können über die RESTful AP
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Bundle/ExampleRxMedicationDispenseSearchset XML %}
+			{% fragment Bundle/ExampleMedicationDispenseSearchResponse XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Bundle/ExampleMedicationDispenseSearchResponse JSON %}
 		</div>
 	</div>
--->
 </div>
 
 
@@ -51,13 +52,14 @@ Um spezifische Details zu einem einzelnen _MedicationDispense_ mittels der RESTf
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Bundle/ExampleRxMedicationDispenseSearchset XML %}
+			{% fragment Bundle/ExampleMedicationDispenseSearchResponse XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Bundle/ExampleMedicationDispenseSearchResponse JSON %}
 		</div>
 	</div>
--->
 </div>
 
 #### Hinweise

--- a/igs/rx/input/pagecontent/query-api-task.md
+++ b/igs/rx/input/pagecontent/query-api-task.md
@@ -36,13 +36,14 @@ Anfragen an die <i>Task</i>-Ressource können über die RESTful API mittels HTTP
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
 			{% fragment Bundle/ExampleRxTaskSearchset XML %}
 		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Bundle/ExampleRxTaskSearchset JSON %}
+		</div>
 	</div>
--->
 </div>
 
 ### Instance API
@@ -60,13 +61,14 @@ Um spezifische Details zu einem einzelnen _Task_ mittels der RESTful API zu erha
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
 	</div>
-<!--
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Bundle/ExampleRxTaskSearchset XML %}
+			{% fragment Task/TaskInReadyState XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Task/TaskInReadyState JSON %}
 		</div>
 	</div>
--->
 </div>
 
 #### Task markieren (Einlösen im EU-Ausland)
@@ -81,5 +83,21 @@ Um spezifische Details zu einem einzelnen _Task_ mittels der RESTful API zu erha
 		<pre>
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
+	</div>
+	<div id="Request-Examples">
+		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Parameters/Example-PATCH-Task-Single-Input-Request-True XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Parameters/Example-PATCH-Task-Single-Input-Request-True JSON %}
+		</div>
+	</div>
+	<div id="Response-Examples">
+		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
+			{% fragment Task/ExampleERPEUTaskInReadyState XML %}
+		</div>
+		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
+			{% fragment Task/ExampleERPEUTaskInReadyState JSON %}
+		</div>
 	</div>
 </div>

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-1.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-1.json
@@ -72,6 +72,12 @@
         "medicationReference" : {
           "reference" : "Medication/5ff1bd22-ce14-484e-be56-d2ba4adeac31"
         },
+        "subject" : {
+          "identifier" : {
+            "system" : "http://fhir.de/sid/gkv/kvid-10",
+            "value" : "X110411319"
+          }
+        },
         "substitution" : {
           "allowedBoolean" : true
         }

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-1.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-1.json
@@ -13,6 +13,7 @@
           "name": "medication",
           "resource": {
             "resourceType": "Medication",
+            "id": "5ff1bd22-ce14-484e-be56-d2ba4adeac31",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
@@ -210,6 +211,7 @@
           "name": "practitioner",
           "resource": {
             "resourceType": "Practitioner",
+            "id": "d6f3b55d-3095-4655-96dc-da3bec21271c",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-1.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-1.json
@@ -1,176 +1,249 @@
 {
-  "resourceType" : "Parameters",
+  "resourceType": "Parameters",
   "id": "output-example-1",
-  "parameter" : [{
-    "name" : "rxPrescription",
-    "part" : [{
-      "name" : "authoredOn",
-      "valueDateTime" : "2024-05-20"
-    },
+  "parameter": [
     {
-      "name" : "medication",
-      "resource" : {
-        "resourceType" : "Medication",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"]
-        },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
-          "valueCoding" : {
-            "code" : "00"
-          }
+      "name": "rxPrescription",
+      "part": [
+        {
+          "name": "authoredOn",
+          "valueDateTime": "2024-05-20"
         },
         {
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
-          "valueBoolean" : false
-        }],
-        "code" : {
-          "coding" : [{
-            "system" : "http://fhir.de/CodeSystem/ifa/pzn",
-            "code" : "07765007"
-          }],
-          "text" : "NEUPRO 8MG/24H PFT 7 ST"
-        },
-        "form" : {
-          "coding" : [{
-            "system" : "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM",
-            "code" : "PFT"
-          }]
-        }
-      }
-    },
-    {
-      "name" : "medicationRequest",
-      "resource" : {
-        "resourceType" : "MedicationRequest",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"]
-        },
-        "authoredOn" : "2024-05-20",
-        "dispenseRequest" : {
-          "quantity" : {
-            "value" : 1,
-            "unit" : "Packung"
-          }
-        },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
-          "valueBoolean" : false
-        },
-        {
-          "extension" : [{
-            "url" : "indicator",
-            "valueBoolean" : false
-          }],
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
-        }],
-        "status" : "active",
-        "intent" : "order",
-        "requester" : {
-          "reference" : "Practitioner/d6f3b55d-3095-4655-96dc-da3bec21271c"
-        },
-        "medicationReference" : {
-          "reference" : "Medication/5ff1bd22-ce14-484e-be56-d2ba4adeac31"
-        },
-        "subject" : {
-          "identifier" : {
-            "system" : "http://fhir.de/sid/gkv/kvid-10",
-            "value" : "X110411319"
-          }
-        },
-        "substitution" : {
-          "allowedBoolean" : true
-        }
-      }
-    },
-    {
-      "name" : "organization",
-      "resource" : {
-        "resourceType" : "Organization",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"]
-        },
-        "address" : [{
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2",
-          "Erdgeschoss"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
+          "name": "medication",
+          "resource": {
+            "resourceType": "Medication",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
+              ]
             },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          },
-          {
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-additionalLocator",
-              "valueString" : "Erdgeschoss"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        },
-        {
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2",
-          "Erdgeschoss"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
+                "valueCoding": {
+                  "code": "00",
+                  "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
+                }
+              },
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
+                "valueBoolean": false
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://fhir.de/CodeSystem/ifa/pzn",
+                  "code": "07765007"
+                }
+              ],
+              "text": "NEUPRO 8MG/24H PFT 7 ST"
             },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          },
-          {
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-additionalLocator",
-              "valueString" : "Erdgeschoss"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        }],
-        "telecom" : [{
-          "system" : "phone",
-          "value" : "030321654987"
+            "form": {
+              "coding": [
+                {
+                  "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM",
+                  "code": "PFT"
+                }
+              ]
+            }
+          }
         },
         {
-          "system" : "email",
-          "value" : "hausarztpraxis@e-mail.de"
-        }]
-      }
-    },
-    {
-      "name" : "practitioner",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"]
+          "name": "medicationRequest",
+          "resource": {
+            "resourceType": "MedicationRequest",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
+              ]
+            },
+            "authoredOn": "2024-05-20",
+            "dispenseRequest": {
+              "quantity": {
+                "value": 1,
+                "unit": "Packung"
+              }
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
+                "valueBoolean": false
+              },
+              {
+                "extension": [
+                  {
+                    "url": "indicator",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
+              }
+            ],
+            "status": "active",
+            "intent": "order",
+            "requester": {
+              "reference": "Practitioner/d6f3b55d-3095-4655-96dc-da3bec21271c"
+            },
+            "medicationReference": {
+              "reference": "Medication/5ff1bd22-ce14-484e-be56-d2ba4adeac31"
+            },
+            "subject": {
+              "identifier": {
+                "system": "http://fhir.de/sid/gkv/kvid-10",
+                "value": "X110411319"
+              }
+            },
+            "substitution": {
+              "allowedBoolean": true
+            }
+          }
         },
-        "name" : [{
-          "use" : "official",
-          "family" : "Schulz",
-          "_family" : {
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-              "valueString" : "Schulz"
-            }]
-          },
-          "given" : ["Ben"]
-        }]
-      }
-    },
-    {
-      "name" : "prescriptionId",
-      "valueString" : "160.100.000.000.037.28"
-    }]
-  }]
+        {
+          "name": "organization",
+          "resource": {
+            "resourceType": "Organization",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": "Hausarztpraxis",
+            "identifier": [
+              {
+                "system": "https://gematik.de/fhir/sid/telematik-id",
+                "value": "2-2.58.00000040"
+              },
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "BSNR"
+                    }
+                  ]
+                },
+                "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+                "value": "724444400"
+              }
+            ],
+            "address": [
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2", "Erdgeschoss"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  },
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-additionalLocator",
+                        "valueString": "Erdgeschoss"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              },
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2", "Erdgeschoss"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  },
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-additionalLocator",
+                        "valueString": "Erdgeschoss"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              }
+            ],
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "030321654987"
+              },
+              {
+                "system": "email",
+                "value": "hausarztpraxis@e-mail.de"
+              }
+            ]
+          }
+        },
+        {
+          "name": "practitioner",
+          "resource": {
+            "resourceType": "Practitioner",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": [
+              {
+                "use": "official",
+                "family": "Schulz",
+                "text": "Ben Schulz",
+                "_family": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                      "valueString": "Schulz"
+                    }
+                  ]
+                },
+                "given": ["Ben"]
+              }
+            ]
+          }
+        },
+        {
+          "name": "prescriptionId",
+          "valueString": "160.100.000.000.037.28"
+        }
+      ]
+    }
+  ]
 }

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-2.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-2.json
@@ -13,6 +13,7 @@
           "name": "medication",
           "resource": {
             "resourceType": "Medication",
+            "id": "86fa62c7-06a0-418e-ba26-e99baa053c07",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
@@ -54,21 +55,16 @@
               ]
             },
             "authoredOn": "2024-05-20",
-            "dosageInstruction": [
-              {
-                "extension": [
-                  {
-                    "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_DosageFlag",
-                    "valueBoolean": true
-                  }
-                ],
-                "text": "1-0-0-0"
-              }
-            ],
             "dispenseRequest": {
               "quantity": {
                 "value": 1,
                 "unit": "Packung"
+              }
+            },
+            "subject": {
+              "identifier": {
+                "system": "http://fhir.de/sid/gkv/kvid-10",
+                "value": "X110411319"
               }
             },
             "extension": [
@@ -199,6 +195,7 @@
           "name": "practitioner",
           "resource": {
             "resourceType": "Practitioner",
+            "id": "bc329f24-3d65-4286-bf06-b54dd6cad655",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-2.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-2.json
@@ -1,178 +1,257 @@
 {
-  "resourceType" : "Parameters",
+  "resourceType": "Parameters",
   "id": "output-example-2",
-  "parameter" : [{
-    "name" : "rxPrescription",
-    "part" : [{
-      "name" : "authoredOn",
-      "valueDateTime" : "2024-05-20"
-    },
+  "parameter": [
     {
-      "name" : "medication",
-      "resource" : {
-        "resourceType" : "Medication",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"]
+      "name": "rxPrescription",
+      "part": [
+        {
+          "name": "authoredOn",
+          "valueDateTime": "2024-05-20"
         },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
-          "valueCoding" : {
-            "code" : "00"
+        {
+          "name": "medication",
+          "resource": {
+            "resourceType": "Medication",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
+              ]
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
+                "valueCoding": {
+                  "code": "00",
+                  "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
+                }
+              },
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
+                "valueBoolean": false
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type",
+                  "code": "wirkstoff"
+                }
+              ]
+            },
+            "form": {
+              "text": "Tabletten"
+            }
           }
         },
         {
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
-          "valueBoolean" : false
-        }],
-        "code" : {
-          "coding" : [{
-            "system" : "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type",
-            "code" : "wirkstoff"
-          }]
+          "name": "medicationRequest",
+          "resource": {
+            "resourceType": "MedicationRequest",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
+              ]
+            },
+            "authoredOn": "2024-05-20",
+            "dosageInstruction": [
+              {
+                "extension": [
+                  {
+                    "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_DosageFlag",
+                    "valueBoolean": true
+                  }
+                ],
+                "text": "1-0-0-0"
+              }
+            ],
+            "dispenseRequest": {
+              "quantity": {
+                "value": 1,
+                "unit": "Packung"
+              }
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
+                "valueBoolean": false
+              },
+              {
+                "extension": [
+                  {
+                    "url": "indicator",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
+              }
+            ],
+            "status": "active",
+            "intent": "order",
+            "requester": {
+              "reference": "Practitioner/bc329f24-3d65-4286-bf06-b54dd6cad655"
+            },
+            "medicationReference": {
+              "reference": "Medication/86fa62c7-06a0-418e-ba26-e99baa053c07"
+            },
+            "note": [
+              {
+                "text": "Bitte längliche Tabletten, da Patient Probleme mit dem Schlucken von runden hat."
+              }
+            ]
+          }
         },
-        "form" : {
-          "text" : "Tabletten"
+        {
+          "name": "organization",
+          "resource": {
+            "resourceType": "Organization",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": "Hausarztpraxis",
+            "identifier": [
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "BSNR"
+                    }
+                  ]
+                },
+                "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+                "value": "724444400"
+              },
+              {
+                "system": "https://gematik.de/fhir/sid/telematik-id",
+                "value": "2-2.58.00000040"
+              }
+            ],
+            "address": [
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              },
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              }
+            ],
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "0301234567"
+              },
+              {
+                "system": "fax",
+                "value": "030123456789"
+              },
+              {
+                "system": "email",
+                "value": "mvz@e-mail.de"
+              }
+            ]
+          }
+        },
+        {
+          "name": "practitioner",
+          "resource": {
+            "resourceType": "Practitioner",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": [
+              {
+                "use": "official",
+                "family": "Freiherr von Müller",
+                "text": "Dr. med. Paul Freiherr von Müller",
+                "_family": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                      "valueString": "von"
+                    },
+                    {
+                      "url": "http://fhir.de/StructureDefinition/humanname-namenszusatz",
+                      "valueString": "Freiherr"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                      "valueString": "Müller"
+                    }
+                  ]
+                },
+                "given": ["Paul"],
+                "prefix": ["Dr. med."],
+                "_prefix": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                        "valueCode": "AC"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "prescriptionId",
+          "valueString": "160.100.000.000.019.82"
         }
-      }
-    },
-    {
-      "name" : "medicationRequest",
-      "resource" : {
-        "resourceType" : "MedicationRequest",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"]
-        },
-        "authoredOn" : "2024-05-20",
-        "dosageInstruction" : [{
-          "extension" : [{
-            "url" : "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_DosageFlag",
-            "valueBoolean" : true
-          }],
-          "text" : "1-0-0-0"
-        }],
-        "dispenseRequest" : {
-          "quantity" : {
-            "value" : 1,
-            "unit" : "Packung"
-          }
-        },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
-          "valueBoolean" : false
-        },
-        {
-          "extension" : [{
-            "url" : "indicator",
-            "valueBoolean" : false
-          }],
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
-        }],
-        "status" : "active",
-        "intent" : "order",
-        "requester" : {
-          "reference" : "Practitioner/bc329f24-3d65-4286-bf06-b54dd6cad655"
-        },
-        "medicationReference" : {
-          "reference" : "Medication/86fa62c7-06a0-418e-ba26-e99baa053c07"
-        },
-        "note" : [{
-          "text" : "Bitte längliche Tabletten, da Patient Probleme mit dem Schlucken von runden hat."
-        }]
-      }
-    },
-    {
-      "name" : "organization",
-      "resource" : {
-        "resourceType" : "Organization",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"]
-        },
-        "address" : [{
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        },
-        {
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        }],
-        "telecom" : [{
-          "system" : "phone",
-          "value" : "0301234567"
-        },
-        {
-          "system" : "fax",
-          "value" : "030123456789"
-        },
-        {
-          "system" : "email",
-          "value" : "mvz@e-mail.de"
-        }]
-      }
-    },
-    {
-      "name" : "practitioner",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"]
-        },
-        "name" : [{
-          "use" : "official",
-          "family" : "Freiherr von Müller",
-          "_family" : {
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-              "valueString" : "von"
-            },
-            {
-              "url" : "http://fhir.de/StructureDefinition/humanname-namenszusatz",
-              "valueString" : "Freiherr"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-              "valueString" : "Müller"
-            }]
-          },
-          "given" : ["Paul"],
-          "prefix" : ["Dr. med."],
-          "_prefix" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
-              "valueCode" : "AC"
-            }]
-          }]
-        }]
-      }
-    },
-    {
-      "name" : "prescriptionId",
-      "valueString" : "160.100.000.000.019.82"
-    }]
-  }]
+      ]
+    }
+  ]
 }

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-3.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-3.json
@@ -13,6 +13,7 @@
           "name": "medication",
           "resource": {
             "resourceType": "Medication",
+            "id": "0d93504e-c6a7-47c1-8ad5-b0c5cf1b8920",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
@@ -50,6 +51,12 @@
               "profile": [
                 "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
               ]
+            },
+            "subject": {
+              "identifier": {
+                "system": "http://fhir.de/sid/gkv/kvid-10",
+                "value": "X110411319"
+              }
             },
             "authoredOn": "2024-05-20",
             "dispenseRequest": {
@@ -184,6 +191,7 @@
           "name": "practitioner",
           "resource": {
             "resourceType": "Practitioner",
+            "id": "667ffd79-42a3-4002-b7ca-6b9098f20ccb",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-3.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-3.json
@@ -1,161 +1,234 @@
 {
-  "resourceType" : "Parameters",
+  "resourceType": "Parameters",
   "id": "output-example-3",
-  "parameter" : [{
-    "name" : "rxPrescription",
-    "part" : [{
-      "name" : "authoredOn",
-      "valueDateTime" : "2024-05-20"
-    },
+  "parameter": [
     {
-      "name" : "medication",
-      "resource" : {
-        "resourceType" : "Medication",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"]
+      "name": "rxPrescription",
+      "part": [
+        {
+          "name": "authoredOn",
+          "valueDateTime": "2024-05-20"
         },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
-          "valueCoding" : {
-            "code" : "00"
+        {
+          "name": "medication",
+          "resource": {
+            "resourceType": "Medication",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
+              ]
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
+                "valueCoding": {
+                  "code": "00",
+                  "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
+                }
+              },
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
+                "valueBoolean": false
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type",
+                  "code": "freitext"
+                }
+              ],
+              "text": "Metformin 850mg Tabletten N3"
+            }
           }
         },
         {
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
-          "valueBoolean" : false
-        }],
-        "code" : {
-          "coding" : [{
-            "system" : "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type",
-            "code" : "freitext"
-          }],
-          "text" : "Metformin 850mg Tabletten N3"
-        }
-      }
-    },
-    {
-      "name" : "medicationRequest",
-      "resource" : {
-        "resourceType" : "MedicationRequest",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"]
-        },
-        "authoredOn" : "2024-05-20",
-        "dispenseRequest" : {
-          "quantity" : {
-            "value" : 1,
-            "unit" : "Packung"
+          "name": "medicationRequest",
+          "resource": {
+            "resourceType": "MedicationRequest",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
+              ]
+            },
+            "authoredOn": "2024-05-20",
+            "dispenseRequest": {
+              "quantity": {
+                "value": 1,
+                "unit": "Packung"
+              }
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
+                "valueBoolean": false
+              },
+              {
+                "extension": [
+                  {
+                    "url": "indicator",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
+              }
+            ],
+            "status": "active",
+            "intent": "order",
+            "requester": {
+              "reference": "Practitioner/667ffd79-42a3-4002-b7ca-6b9098f20ccb"
+            },
+            "medicationReference": {
+              "reference": "Medication/0d93504e-c6a7-47c1-8ad5-b0c5cf1b8920"
+            },
+            "substitution": {
+              "allowedBoolean": true
+            }
           }
         },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
-          "valueBoolean" : false
+        {
+          "name": "organization",
+          "resource": {
+            "resourceType": "Organization",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": "Hausarztpraxis",
+            "identifier": [
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "BSNR"
+                    }
+                  ]
+                },
+                "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+                "value": "724444400"
+              },
+              {
+                "system": "https://gematik.de/fhir/sid/telematik-id",
+                "value": "2-2.58.00000040"
+              }
+            ],
+            "address": [
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              },
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              }
+            ],
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "0301234567"
+              },
+              {
+                "system": "fax",
+                "value": "030123456789"
+              },
+              {
+                "system": "email",
+                "value": "mvz@e-mail.de"
+              }
+            ]
+          }
         },
         {
-          "extension" : [{
-            "url" : "indicator",
-            "valueBoolean" : false
-          }],
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
-        }],
-        "status" : "active",
-        "intent" : "order",
-        "requester" : {
-          "reference" : "Practitioner/667ffd79-42a3-4002-b7ca-6b9098f20ccb"
+          "name": "practitioner",
+          "resource": {
+            "resourceType": "Practitioner",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": [
+              {
+                "use": "official",
+                "family": "Schneider",
+                "text": "Dr. med. Emma Schneider",
+                "_family": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                      "valueString": "Schneider"
+                    }
+                  ]
+                },
+                "given": ["Emma"],
+                "prefix": ["Dr. med."],
+                "_prefix": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                        "valueCode": "AC"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
         },
-        "medicationReference" : {
-          "reference" : "Medication/0d93504e-c6a7-47c1-8ad5-b0c5cf1b8920"
-        },
-        "substitution" : {
-          "allowedBoolean" : true
+        {
+          "name": "prescriptionId",
+          "valueString": "160.100.000.000.023.70"
         }
-      }
-    },
-    {
-      "name" : "organization",
-      "resource" : {
-        "resourceType" : "Organization",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"]
-        },
-        "address" : [{
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        },
-        {
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        }],
-        "telecom" : [{
-          "system" : "phone",
-          "value" : "0301234567"
-        },
-        {
-          "system" : "fax",
-          "value" : "030123456789"
-        },
-        {
-          "system" : "email",
-          "value" : "mvz@e-mail.de"
-        }]
-      }
-    },
-    {
-      "name" : "practitioner",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"]
-        },
-        "name" : [{
-          "use" : "official",
-          "family" : "Schneider",
-          "_family" : {
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-              "valueString" : "Schneider"
-            }]
-          },
-          "given" : ["Emma"],
-          "prefix" : ["Dr. med."],
-          "_prefix" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
-              "valueCode" : "AC"
-            }]
-          }]
-        }]
-      }
-    },
-    {
-      "name" : "prescriptionId",
-      "valueString" : "160.100.000.000.023.70"
-    }]
-  }]
+      ]
+    }
+  ]
 }

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-4.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-4.json
@@ -1,181 +1,258 @@
 {
-  "resourceType" : "Parameters",
+  "resourceType": "Parameters",
   "id": "output-example-4",
-  "parameter" : [{
-    "name" : "rxPrescription",
-    "part" : [{
-      "name" : "authoredOn",
-      "valueDateTime" : "2024-05-20"
-    },
+  "parameter": [
     {
-      "name" : "medication",
-      "resource" : {
-        "resourceType" : "Medication",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"]
+      "name": "rxPrescription",
+      "part": [
+        {
+          "name": "authoredOn",
+          "valueDateTime": "2024-05-20"
         },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
-          "valueCoding" : {
-            "code" : "00"
+        {
+          "name": "medication",
+          "resource": {
+            "resourceType": "Medication",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
+              ]
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
+                "valueCoding": {
+                  "code": "00",
+                  "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
+                }
+              },
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
+                "valueBoolean": false
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://fhir.de/CodeSystem/ifa/pzn",
+                  "code": "00814665"
+                }
+              ],
+              "text": "Januvia® 50 mg 28 Filmtabletten N1"
+            },
+            "form": {
+              "coding": [
+                {
+                  "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM",
+                  "code": "FTA"
+                }
+              ]
+            }
           }
         },
         {
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
-          "valueBoolean" : false
-        }],
-        "code" : {
-          "coding" : [{
-            "system" : "http://fhir.de/CodeSystem/ifa/pzn",
-            "code" : "00814665"
-          }],
-          "text" : "Januvia® 50 mg 28 Filmtabletten N1"
+          "name": "medicationRequest",
+          "resource": {
+            "resourceType": "MedicationRequest",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
+              ]
+            },
+            "authoredOn": "2024-05-20",
+            "basedOn": [
+              {
+                "identifier": {
+                  "system": "https://gematik.de/fhir/sid/emp-identifier",
+                  "value": "8cc8e04b-6df7-43b5-b847-508268e95ba7"
+                }
+              }
+            ],
+            "dispenseRequest": {
+              "quantity": {
+                "value": 1,
+                "unit": "Packung"
+              }
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
+                "valueBoolean": false
+              },
+              {
+                "extension": [
+                  {
+                    "url": "indicator",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
+              }
+            ],
+            "status": "active",
+            "intent": "order",
+            "requester": {
+              "reference": "urn:uuid:bc329f24-3d65-4286-bf06-b54dd6cad655"
+            },
+            "medicationReference": {
+              "reference": "urn:uuid:47076fb4-dc5c-4f75-85f6-b200033b3280"
+            },
+            "substitution": {
+              "allowedBoolean": true
+            }
+          }
         },
-        "form" : {
-          "coding" : [{
-            "system" : "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM",
-            "code" : "FTA"
-          }]
+        {
+          "name": "organization",
+          "resource": {
+            "resourceType": "Organization",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": "Hausarztpraxis",
+            "identifier": [
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "BSNR"
+                    }
+                  ]
+                },
+                "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+                "value": "724444400"
+              },
+              {
+                "system": "https://gematik.de/fhir/sid/telematik-id",
+                "value": "2-2.58.00000040"
+              }
+            ],
+            "address": [
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              },
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              }
+            ],
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "0301234567"
+              },
+              {
+                "system": "fax",
+                "value": "030123456789"
+              },
+              {
+                "system": "email",
+                "value": "mvz@e-mail.de"
+              }
+            ]
+          }
+        },
+        {
+          "name": "practitioner",
+          "resource": {
+            "resourceType": "Practitioner",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": [
+              {
+                "use": "official",
+                "family": "Freiherr von Müller",
+                "text": "Dr. med. Paul Freiherr von Müller",
+                "_family": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                      "valueString": "von"
+                    },
+                    {
+                      "url": "http://fhir.de/StructureDefinition/humanname-namenszusatz",
+                      "valueString": "Freiherr"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                      "valueString": "Müller"
+                    }
+                  ]
+                },
+                "given": ["Paul"],
+                "prefix": ["Dr. med."],
+                "_prefix": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                        "valueCode": "AC"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "prescriptionId",
+          "valueString": "160.100.000.000.006.24"
         }
-      }
-    },
-    {
-      "name" : "medicationRequest",
-      "resource" : {
-        "resourceType" : "MedicationRequest",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"]
-        },
-        "authoredOn" : "2024-05-20",
-        "basedOn" : [{
-          "identifier" : {
-            "system" : "https://gematik.de/fhir/sid/emp-identifier",
-            "value" : "8cc8e04b-6df7-43b5-b847-508268e95ba7"
-          }
-        }],
-        "dispenseRequest" : {
-          "quantity" : {
-            "value" : 1,
-            "unit" : "Packung"
-          }
-        },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
-          "valueBoolean" : false
-        },
-        {
-          "extension" : [{
-            "url" : "indicator",
-            "valueBoolean" : false
-          }],
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
-        }],
-        "status" : "active",
-        "intent" : "order",
-        "requester" : {
-          "reference" : "urn:uuid:bc329f24-3d65-4286-bf06-b54dd6cad655"
-        },
-        "medicationReference" : {
-          "reference" : "urn:uuid:47076fb4-dc5c-4f75-85f6-b200033b3280"
-        },
-        "substitution" : {
-          "allowedBoolean" : true
-        }
-      }
-    },
-    {
-      "name" : "organization",
-      "resource" : {
-        "resourceType" : "Organization",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"]
-        },
-        "address" : [{
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        },
-        {
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        }],
-        "telecom" : [{
-          "system" : "phone",
-          "value" : "0301234567"
-        },
-        {
-          "system" : "fax",
-          "value" : "030123456789"
-        },
-        {
-          "system" : "email",
-          "value" : "mvz@e-mail.de"
-        }]
-      }
-    },
-    {
-      "name" : "practitioner",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"]
-        },
-        "name" : [{
-          "use" : "official",
-          "family" : "Freiherr von Müller",
-          "_family" : {
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-              "valueString" : "von"
-            },
-            {
-              "url" : "http://fhir.de/StructureDefinition/humanname-namenszusatz",
-              "valueString" : "Freiherr"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-              "valueString" : "Müller"
-            }]
-          },
-          "given" : ["Paul"],
-          "prefix" : ["Dr. med."],
-          "_prefix" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
-              "valueCode" : "AC"
-            }]
-          }]
-        }]
-      }
-    },
-    {
-      "name" : "prescriptionId",
-      "valueString" : "160.100.000.000.006.24"
-    }]
-  }]
+      ]
+    }
+  ]
 }

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-4.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-4.json
@@ -59,6 +59,12 @@
                 "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
               ]
             },
+            "subject": {
+              "identifier": {
+                "system": "http://fhir.de/sid/gkv/kvid-10",
+                "value": "X110411319"
+              }
+            },
             "authoredOn": "2024-05-20",
             "basedOn": [
               {

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-5.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-5.json
@@ -1,181 +1,258 @@
 {
-  "resourceType" : "Parameters",
+  "resourceType": "Parameters",
   "id": "output-example-5",
-  "parameter" : [{
-    "name" : "rxPrescription",
-    "part" : [{
-      "name" : "authoredOn",
-      "valueDateTime" : "2025-05-20"
-    },
+  "parameter": [
     {
-      "name" : "medication",
-      "resource" : {
-        "resourceType" : "Medication",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"]
+      "name": "rxPrescription",
+      "part": [
+        {
+          "name": "authoredOn",
+          "valueDateTime": "2025-05-20"
         },
-        "extension" : [{
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
-          "valueCoding" : {
-            "code" : "00"
+        {
+          "name": "medication",
+          "resource": {
+            "resourceType": "Medication",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
+              ]
+            },
+            "extension": [
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
+                "valueCoding": {
+                  "code": "00",
+                  "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
+                }
+              },
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
+                "valueBoolean": false
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type",
+                  "code": "rezeptur"
+                }
+              ]
+            },
+            "form": {
+              "text": "Lösung"
+            }
           }
         },
         {
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-id-vaccine-extension",
-          "valueBoolean" : false
-        }],
-        "code" : {
-          "coding" : [{
-            "system" : "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type",
-            "code" : "rezeptur"
-          }]
-        },
-        "form" : {
-          "text" : "Lösung"
-        }
-      }
-    },
-    {
-      "name" : "medicationRequest",
-      "resource" : {
-        "resourceType" : "MedicationRequest",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"]
-        },
-        "authoredOn" : "2025-05-20",
-        "dosageInstruction" : [{
-          "text" : "1–3mal/Tag auf die erkrankten Hautstellen auftragen"
-        }],
-        "dispenseRequest" : {
-          "quantity" : {
-            "value" : 1,
-            "unit" : "Packung"
+          "name": "medicationRequest",
+          "resource": {
+            "resourceType": "MedicationRequest",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
+              ]
+            },
+            "authoredOn": "2025-05-20",
+            "dosageInstruction": [
+              {
+                "text": "1–3mal/Tag auf die erkrankten Hautstellen auftragen"
+              }
+            ],
+            "dispenseRequest": {
+              "quantity": {
+                "value": 1,
+                "unit": "Packung"
+              }
+            },
+            "extension": [
+              {
+                "extension": [
+                  {
+                    "url": "algorithmVersion",
+                    "valueString": "1.0.0"
+                  },
+                  {
+                    "url": "language",
+                    "valueCode": "de-DE"
+                  }
+                ],
+                "url": "http://ig.fhir.de/igs/medication/StructureDefinition/GeneratedDosageInstructionsMeta"
+              },
+              {
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
+                "valueBoolean": false
+              },
+              {
+                "extension": [
+                  {
+                    "url": "indicator",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
+              },
+              {
+                "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationRequest.renderedDosageInstruction",
+                "valueMarkdown": "1–3mal/Tag auf die erkrankten Hautstellen auftragen"
+              }
+            ],
+            "status": "active",
+            "intent": "order",
+            "requester": {
+              "reference": "Practitioner/ec5b4fcf-9739-4055-b23c-a5b3a65beb66"
+            },
+            "medicationReference": {
+              "reference": "Medication/5cd916fc-2ae2-4148-b016-911ec5f4c0a5"
+            },
+            "substitution": {
+              "allowedBoolean": true
+            }
           }
         },
-        "extension" : [{
-          "extension" : [{
-            "url" : "algorithmVersion",
-            "valueString" : "1.0.0"
-          },
-          {
-            "url" : "language",
-            "valueCode" : "de-DE"
-          }],
-          "url" : "http://ig.fhir.de/igs/medication/StructureDefinition/GeneratedDosageInstructionsMeta"
+        {
+          "name": "organization",
+          "resource": {
+            "resourceType": "Organization",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": "Hausarztpraxis",
+            "identifier": [
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "BSNR"
+                    }
+                  ]
+                },
+                "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+                "value": "724444400"
+              },
+              {
+                "system": "https://gematik.de/fhir/sid/telematik-id",
+                "value": "2-2.58.00000040"
+              }
+            ],
+            "address": [
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              },
+              {
+                "type": "both",
+                "line": ["Herbert-Lewin-Platz 2"],
+                "_line": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                        "valueString": "2"
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                        "valueString": "Herbert-Lewin-Platz"
+                      }
+                    ]
+                  }
+                ],
+                "city": "Berlin",
+                "postalCode": "10623",
+                "country": "D"
+              }
+            ],
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "0301234567"
+              },
+              {
+                "system": "fax",
+                "value": "030123456789"
+              },
+              {
+                "system": "email",
+                "value": "mvz@e-mail.de"
+              }
+            ]
+          }
         },
         {
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/indicator-ser-extension",
-          "valueBoolean" : false
+          "name": "practitioner",
+          "resource": {
+            "resourceType": "Practitioner",
+            "meta": {
+              "profile": [
+                "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"
+              ],
+              "tag": [
+                {
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/Origin",
+                  "code": "ldap"
+                }
+              ]
+            },
+            "name": [
+              {
+                "use": "official",
+                "family": "Schmidt",
+                "text": "Dr. Hanna Schmidt",
+                "_family": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                      "valueString": "Schmidt"
+                    }
+                  ]
+                },
+                "given": ["Hanna"],
+                "prefix": ["Dr."],
+                "_prefix": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                        "valueCode": "AC"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
         },
         {
-          "extension" : [{
-            "url" : "indicator",
-            "valueBoolean" : false
-          }],
-          "url" : "https://gematik.de/fhir/epa-medication/StructureDefinition/multiple-prescription-extension"
-        },
-        {
-          "url" : "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationRequest.renderedDosageInstruction",
-          "valueMarkdown" : "1–3mal/Tag auf die erkrankten Hautstellen auftragen"
-        }],
-        "status" : "active",
-        "intent" : "order",
-        "requester" : {
-          "reference" : "Practitioner/ec5b4fcf-9739-4055-b23c-a5b3a65beb66"
-        },
-        "medicationReference" : {
-          "reference" : "Medication/5cd916fc-2ae2-4148-b016-911ec5f4c0a5"
-        },
-        "substitution" : {
-          "allowedBoolean" : true
+          "name": "prescriptionId",
+          "valueString": "160.100.000.000.024.67"
         }
-      }
-    },
-    {
-      "name" : "organization",
-      "resource" : {
-        "resourceType" : "Organization",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"]
-        },
-        "address" : [{
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        },
-        {
-          "type" : "both",
-          "line" : ["Herbert-Lewin-Platz 2"],
-          "_line" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
-              "valueString" : "2"
-            },
-            {
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
-              "valueString" : "Herbert-Lewin-Platz"
-            }]
-          }],
-          "city" : "Berlin",
-          "postalCode" : "10623",
-          "country" : "D"
-        }],
-        "telecom" : [{
-          "system" : "phone",
-          "value" : "0301234567"
-        },
-        {
-          "system" : "fax",
-          "value" : "030123456789"
-        },
-        {
-          "system" : "email",
-          "value" : "mvz@e-mail.de"
-        }]
-      }
-    },
-    {
-      "name" : "practitioner",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "meta" : {
-          "profile" : ["https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"]
-        },
-        "name" : [{
-          "use" : "official",
-          "family" : "Schmidt",
-          "_family" : {
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-              "valueString" : "Schmidt"
-            }]
-          },
-          "given" : ["Hanna"],
-          "prefix" : ["Dr."],
-          "_prefix" : [{
-            "extension" : [{
-              "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
-              "valueCode" : "AC"
-            }]
-          }]
-        }]
-      }
-    },
-    {
-      "name" : "prescriptionId",
-      "valueString" : "160.100.000.000.024.67"
-    }]
-  }]
+      ]
+    }
+  ]
 }

--- a/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-5.json
+++ b/igs/rx/input/resources/transformed-kbv-bundles/Parameters-output-example-5.json
@@ -13,6 +13,7 @@
           "name": "medication",
           "resource": {
             "resourceType": "Medication",
+            "id": "5cd916fc-2ae2-4148-b016-911ec5f4c0a5",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication"
@@ -52,6 +53,12 @@
               "profile": [
                 "https://gematik.de/fhir/epa-medication/StructureDefinition/epa-medication-request"
               ]
+            },
+            "subject": {
+              "identifier": {
+                "system": "http://fhir.de/sid/gkv/kvid-10",
+                "value": "X110411319"
+              }
             },
             "authoredOn": "2025-05-20",
             "dosageInstruction": [
@@ -208,6 +215,7 @@
           "name": "practitioner",
           "resource": {
             "resourceType": "Practitioner",
+            "id": "ec5b4fcf-9739-4055-b23c-a5b3a65beb66",
             "meta": {
               "profile": [
                 "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory"

--- a/igs/rx/package.json
+++ b/igs/rx/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "de.basisprofil.r4": "1.5.4",
+    "de.basisprofil.r4": "1.6.0",
     "de.gematik.tiflow": "2.0.0-ballot.2",
     "de.gematik.ti": "1.4.0-ballot.2"
   }

--- a/igs/rx/package.json
+++ b/igs/rx/package.json
@@ -11,6 +11,6 @@
     "hl7.fhir.r4.core": "4.0.1",
     "de.basisprofil.r4": "1.5.4",
     "de.gematik.tiflow": "2.0.0-ballot.2",
-    "de.gematik.ti": "1.4.0-ballot.1"
+    "de.gematik.ti": "1.4.0-ballot.2"
   }
 }

--- a/igs/rx/sushi-config.yaml
+++ b/igs/rx/sushi-config.yaml
@@ -303,7 +303,10 @@ parameters:
     - Parameters/*
     - CapabilityStatement/*
     - Provenance/*
+    - Communication/*
     - Consent/*
+    - Task/*
+    - AuditEvent/*    
   no-validate:
     - Bundle/1f339db0-9e55-4946-9dfa-f1b30953be9b
     - Bundle/9c85a2a5-92ee-4a57-83cb-ba90a0df2a21

--- a/igs/rx/sushi-config.yaml
+++ b/igs/rx/sushi-config.yaml
@@ -16,8 +16,8 @@ publisher:
   email: erp-umsetzung@gematik.de
 
 dependencies:
-  hl7.fhir.uv.xver-r5.r4: latest
-  de.basisprofil.r4: 1.5.4
+  hl7.fhir.uv.xver-r5.r4: 0.1.0
+  de.basisprofil.r4: 1.6.0
   de.gematik.ti: 1.4.0-ballot.2
   de.gematik.tiflow: 2.0.0-ballot.2
 
@@ -272,6 +272,7 @@ parameters:
     - https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense
     - https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task
     - https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_AvailabilityStatus
+    - https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_OrganizationType
     - https://gematik.de/fhir/structure-comparer/StructureMap/GEMErpPrMedicationMap
     - https://gematik.de/fhir/structure-comparer/StructureMap/GEMErpPrMedicationdispenseMap
     - https://gematik.de/fhir/structure-comparer/StructureMap/KBVPrErpBundleMap

--- a/igs/rx/sushi-config.yaml
+++ b/igs/rx/sushi-config.yaml
@@ -18,7 +18,7 @@ publisher:
 dependencies:
   hl7.fhir.uv.xver-r5.r4: latest
   de.basisprofil.r4: 1.5.4
-  de.gematik.ti: 1.4.0-ballot.1
+  de.gematik.ti: 1.4.0-ballot.2
   de.gematik.tiflow: 2.0.0-ballot.2
 
 applyExtensionMetadataToRoot: false

--- a/igs/rx/sushi-config.yaml
+++ b/igs/rx/sushi-config.yaml
@@ -324,30 +324,30 @@ parameters:
     - StructureMap/KBVPrErpPrescriptionMap
     - StructureMap/KBVPrForOrganizationMap
     - StructureMap/KBVPrForPractitionerMap
-    - Bundle/Bundle-AcceptOperation
-    - Bundle/ExampleAcceptResponseBundle
-    - Bundle/ExampleRxCommunicationSearchset
-    - Bundle/ExampleRxMedicationDispenseSearchset
-    - Bundle/ExampleRxTaskSearchset
-    - Bundle/dffbfd6a-5712-4798-bdc8-07201eb77ab8
-    - Bundle/example-searchset-auditevent
-    - Bundle/example-searchset-consent
-    - Bundle/example-searchset-medicationdispense
-    - Bundle/example-searchset-task
+    #- Bundle/Bundle-AcceptOperation
+    #- Bundle/ExampleAcceptResponseBundle
+    #- Bundle/ExampleRxCommunicationSearchset
+    #- Bundle/ExampleRxMedicationDispenseSearchset
+    #- Bundle/ExampleRxTaskSearchset
+    #- Bundle/dffbfd6a-5712-4798-bdc8-07201eb77ab8
+    #- Bundle/example-searchset-auditevent
+    #- Bundle/example-searchset-consent
+    #- Bundle/example-searchset-medicationdispense
+    #- Bundle/example-searchset-task
     - Communication/2be1c6ac-5d10-47f6-84ee-8318b2c22c76
     - Communication/7977a4ab-97a9-4d95-afb3-6c4c1e2ac596
     - Communication/a218a36e-f2fd-4603-ba67-c827acfef01b
     - Consent/QueryConsentCHARGCONS
-    - Task/9b48f82c-9c11-4a57-aa72-a805f9537a82
-    - Task/TaskInClosedState
-    - Task/TaskInReadyState
-    - Task/d70932d1-9e1c-483c-b2d4-b7dced09b35e
-    - Task/f5c21409-b84b-4125-8649-5630a00906b1
+    #- Task/9b48f82c-9c11-4a57-aa72-a805f9537a82
+    #- Task/TaskInClosedState
+    #- Task/TaskInReadyState
+    #- Task/d70932d1-9e1c-483c-b2d4-b7dced09b35e
+    #- Task/f5c21409-b84b-4125-8649-5630a00906b1
     - Parameters/output-example-1
     - Parameters/output-example-2
     - Parameters/output-example-3
     - Parameters/output-example-4
     - Parameters/output-example-5
-    - AuditEvent/9361863d-fec0-4ba9-8776-7905cf1b0cfa
+    #- AuditEvent/9361863d-fec0-4ba9-8776-7905cf1b0cfa
     - StructureDefinition/logical-eu-dispense-data
   #autoload-resources: true

--- a/igs/rx/sushi-config.yaml
+++ b/igs/rx/sushi-config.yaml
@@ -324,30 +324,30 @@ parameters:
     - StructureMap/KBVPrErpPrescriptionMap
     - StructureMap/KBVPrForOrganizationMap
     - StructureMap/KBVPrForPractitionerMap
-    #- Bundle/Bundle-AcceptOperation
-    #- Bundle/ExampleAcceptResponseBundle
-    #- Bundle/ExampleRxCommunicationSearchset
-    #- Bundle/ExampleRxMedicationDispenseSearchset
-    #- Bundle/ExampleRxTaskSearchset
-    #- Bundle/dffbfd6a-5712-4798-bdc8-07201eb77ab8
-    #- Bundle/example-searchset-auditevent
-    #- Bundle/example-searchset-consent
-    #- Bundle/example-searchset-medicationdispense
-    #- Bundle/example-searchset-task
+    # - Bundle/Bundle-AcceptOperation
+    # - Bundle/ExampleAcceptResponseBundle
+    # - Bundle/ExampleRxCommunicationSearchset
+    # - Bundle/ExampleRxMedicationDispenseSearchset
+    # - Bundle/ExampleRxTaskSearchset
+    # - Bundle/dffbfd6a-5712-4798-bdc8-07201eb77ab8
+    # - Bundle/example-searchset-auditevent
+    # - Bundle/example-searchset-consent
+    # - Bundle/example-searchset-medicationdispense
+    # - Bundle/example-searchset-task
     - Communication/2be1c6ac-5d10-47f6-84ee-8318b2c22c76
     - Communication/7977a4ab-97a9-4d95-afb3-6c4c1e2ac596
     - Communication/a218a36e-f2fd-4603-ba67-c827acfef01b
-    - Consent/QueryConsentCHARGCONS
-    #- Task/9b48f82c-9c11-4a57-aa72-a805f9537a82
-    #- Task/TaskInClosedState
-    #- Task/TaskInReadyState
-    #- Task/d70932d1-9e1c-483c-b2d4-b7dced09b35e
-    #- Task/f5c21409-b84b-4125-8649-5630a00906b1
-    - Parameters/output-example-1
-    - Parameters/output-example-2
-    - Parameters/output-example-3
-    - Parameters/output-example-4
-    - Parameters/output-example-5
-    #- AuditEvent/9361863d-fec0-4ba9-8776-7905cf1b0cfa
-    - StructureDefinition/logical-eu-dispense-data
+    # - Consent/QueryConsentCHARGCONS
+    # - Task/9b48f82c-9c11-4a57-aa72-a805f9537a82
+    # - Task/TaskInClosedState
+    # - Task/TaskInReadyState
+    # - Task/d70932d1-9e1c-483c-b2d4-b7dced09b35e
+    # - Task/f5c21409-b84b-4125-8649-5630a00906b1
+    # - Parameters/output-example-1
+    # - Parameters/output-example-2
+    # - Parameters/output-example-3
+    # - Parameters/output-example-4
+    # - Parameters/output-example-5
+    # - AuditEvent/9361863d-fec0-4ba9-8776-7905cf1b0cfa
+    # - StructureDefinition/logical-eu-dispense-data
   #autoload-resources: true

--- a/igs/rx/sushi-config.yaml
+++ b/igs/rx/sushi-config.yaml
@@ -8,7 +8,7 @@ version: 2.0.0-ballot.2
 # version: 0.9.0
 date: 2026-06-30
 copyrightYear: 2026+
-releaseLabel: ballot # ci-build, ballot, release
+releaseLabel: ci-build # ci-build, ballot, release
 jurisdiction: urn:iso:std:iso:3166#DE "Germany" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:
   name: gematik GmbH

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "4.0.1"
   ],
   "dependencies": {
-    "hl7.fhir.uv.xver-r5.r4": "0.0.1-snapshot-2",
+    "hl7.fhir.uv.xver-r5.r4": "0.1.0",
     "de.gematik.erezept-workflow.r4": "1.6.1",
-    "de.basisprofil.r4": "1.5.4",
+    "de.basisprofil.r4": "1.6.0",
     "de.fhir.medication": "1.0.3",
     "de.gematik.epa.medication": "1.3.0",
     "de.gematik.fhir.directory": "1.0.0",
     "de.gematik.terminology": "1.0.8",
-    "de.gematik.ti": "1.4.0-ballot.1"
+    "de.gematik.ti": "1.4.0-ballot.2"
   }
 }


### PR DESCRIPTION
- Created example FSH files for $activate, $close, $create, $dispense, $eu-close, $get-eu-prescriptions, and $reject operations, including error responses.
- Updated existing FSH profiles and page content to reflect new examples and improve clarity.
- Enhanced documentation for operation requests and responses, including JSON and XML examples.
- Added missing parameters and examples for EU access permission operations.
- Updated sushi configuration to include new resources and ensure proper validation.