### PR TITLE
TMD-3439 anpassen beispiele für TI-Flow-FD-RX Communication

### DIFF
--- a/igs/rx/input/fsh/aliases.fsh
+++ b/igs/rx/input/fsh/aliases.fsh
@@ -56,9 +56,11 @@ Alias: $prescription-id-ns = https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS
 Alias: $eu-access-code-ns = https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_EU_AccessCode
 Alias: $cs-flowtype = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType
 Alias: $cs-features = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_Features
+Alias: $cs-availability-status = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_AvailabilityStatus
 Alias: $ex-capability-feature = https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_CapabilityStatement_Feature
 Alias: $ex-capability-environment = https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_CapabilityStatement_Environment
-
+Alias: $ex-supply-options-type = https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_SupplyOptionsType
+Alias: $ex-availability-state = https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AvailabilityState
 // TI Common
 Alias: $ti-oo = https://gematik.de/fhir/ti/CodeSystem/operation-outcome-details-codes
 

--- a/igs/rx/input/fsh/examples/communication_examples/Example_Communication_DispReq.fsh
+++ b/igs/rx/input/fsh/examples/communication_examples/Example_Communication_DispReq.fsh
@@ -3,8 +3,6 @@ InstanceOf: GEM_ERP_PR_Communication_DispReq
 Title: "Zuweisung des Patienten an die Apotheke"
 Description: "Beispiel für eine Nachricht des Patienten an die Apotheke zur Anfrage der Medikamentenabgabe mit AccessCode"
 Usage: #inline
-* meta.tag[+].display = "Dispense Request from Patient to Pharmacy"
-* meta.tag[+].display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
 * basedOn.reference = "Task/160.000.033.491.280.78"
 * insert TaskExension(160)
 * insert ApoTelematikID(recipient.identifier)
@@ -25,3 +23,53 @@ Description: "Example response for GET /Communication"
 * entry[+].fullUrl = "https://erp-ref.example.org/Communication/ExampleCommunicationDispReq"
 * entry[=].resource = ExampleCommunicationDispReq
 * entry[=].search.mode = #match
+
+/*
+Instance: INVALID-Communication-DispenseRequest-DiGA
+InstanceOf: GEM_ERP_PR_Communication_DispReq
+Title: "Communication message sent by patient to insurance company to request the dispensation of a DiGA by providing the AccessCode"
+Usage: #example
+* meta.tag.display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
+* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
+* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#162 "Flowtype für Digitale Gesundheitsanwendungen"
+* basedOn.reference = "Task/162.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
+* status = #unknown
+* recipient[+].identifier.system = $identifier-telematik-id
+* recipient[=].identifier.value = "8-SMC-B-Testkarte-883110000123465"
+* sender.identifier.system = $identifier-kvid-10
+* sender.identifier.value = "X234567890"
+* insert DateTimeStamp(sent)
+* payload.contentString = "U.N.V.E.U"
+
+Instance: INVALID-Communication-DispenseRequest-INV-flowType
+InstanceOf: GEM_ERP_PR_Communication_DispReq
+Title: "UNGÜLTIG: DiGA-Abgabe-Anfrage mit falschem FlowType"
+Description: "Ungültiges Beispiel für eine DiGA-Abgabe-Anfrage mit inkorrektem FlowType zur Validierung"
+Usage: #example
+* meta.tag.display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
+* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
+* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#162 "Flowtype für Digitale Gesundheitsanwendungen"
+* basedOn.reference = "Task/160.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
+* status = #unknown
+* recipient[+].identifier.system = $identifier-telematik-id
+* recipient[=].identifier.value = "8-SMC-B-Testkarte-883110000123465"
+* sender.identifier.system = $identifier-kvid-10
+* sender.identifier.value = "X234567890"
+* insert DateTimeStamp(sent)
+
+Instance: INVALID-Communication-DispenseRequest
+InstanceOf: GEM_ERP_PR_Communication_DispReq
+Title: "UNGÜLTIG: Abgabe-Anfrage ohne Payload"
+Description: "Ungültiges Beispiel für eine Abgabe-Anfrage ohne erforderlichen Payload-Inhalt zur Validierung"
+Usage: #example
+* meta.tag.display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
+* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
+* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#160 "Flowtype für Apothekenpflichtige Arzneimittel"
+* basedOn.reference = "Task/160.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
+* status = #unknown
+* recipient[+].identifier.system = $identifier-telematik-id
+* recipient[=].identifier.value = "3-SMC-B-Testkarte-883110000123465"
+* sender.identifier.system = $identifier-kvid-10
+* sender.identifier.value = "X234567890"
+* insert DateTimeStamp(sent)
+*/

--- a/igs/rx/input/fsh/examples/communication_examples/Example_Communication_DispReq.fsh
+++ b/igs/rx/input/fsh/examples/communication_examples/Example_Communication_DispReq.fsh
@@ -1,86 +1,27 @@
-Instance: Communication_DispenseRequest
+Instance: ExampleCommunicationDispReq
 InstanceOf: GEM_ERP_PR_Communication_DispReq
 Title: "Zuweisung des Patienten an die Apotheke"
 Description: "Beispiel für eine Nachricht des Patienten an die Apotheke zur Anfrage der Medikamentenabgabe mit AccessCode"
-Usage: #example
-* id = "a218a36e-f2fd-4603-ba67-c827acfef01b"
+Usage: #inline
 * meta.tag[+].display = "Dispense Request from Patient to Pharmacy"
 * meta.tag[+].display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
-* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
-* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#160 "Flowtype für Apothekenpflichtige Arzneimittel"
-* basedOn.reference = "Task/160.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
-* status = #unknown
-* recipient[+].identifier.system = $identifier-telematik-id
-* recipient[=].identifier.value = "3-SMC-B-Testkarte-883110000123465"
-* sender.identifier.system = $identifier-kvid-10
-* sender.identifier.value = "X234567890"
+* basedOn.reference = "Task/160.000.033.491.280.78"
+* insert TaskExension(160)
+* insert ApoTelematikID(recipient.identifier)
+* insert GKV_Identifier(sender.identifier)
 * insert DateTimeStamp(sent)
-* payload.contentString = "{ \"version\": \"1\", \"supplyOptionsType\": \"delivery\", \"name\": \"Dr. Maximilian von Muster\", \"address\": [ \"wohnhaft bei Emilia Fischer\", \"Bundesallee 312\", \"123. OG\", \"12345 Berlin\" ], \"hint\": \"Bitte im Morsecode klingeln: -.-.\", \"phone\": \"004916094858168\" }"
+* status = #unknown
+* payload.contentString = "{ \"version\": 1, \"supplyOptionsType\": \"onPremise\", \"name\": \"Dr. Maximilian von Muster\", \"address\": [ \"wohnhaft bei Emilia Fischer\", \"Bundesallee 312\", \"123. OG\", \"12345 Berlin\" ], \"phone\": \"004916094858168\" }"
 
-Instance: Communication_DispenseRequest_DiGA
-InstanceOf: GEM_ERP_PR_Communication_DispReq
-Title: "DiGA-Zuweisung des Patienten an die Krankenkasse"
-Description: "Beispiel für eine Nachricht des Patienten an die Krankenkasse zur Anfrage der DiGA-Abgabe mit AccessCode"
+Instance: ExampleCommunicationGetDispReq
+InstanceOf: Bundle
 Usage: #example
-* id = "2be1c6ac-5d10-47f6-84ee-8318b2c22c76"
-* meta.tag[+].display = "Dispense Request from Patient to Health Care Provider"
-* meta.tag[+].display = "Communication message sent by patient to Health Care Provider to request the redeemCode for a DiGA"
-* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
-* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#162 "Flowtype für Digitale Gesundheitsanwendungen"
-* basedOn.reference = "Task/162.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
-* status = #unknown
-* recipient[+].identifier.system = $identifier-telematik-id
-* recipient[=].identifier.value = "8-SMC-B-Testkarte-883110000123465"
-* sender.identifier.system = $identifier-kvid-10
-* sender.identifier.value = "X234567890"
-* insert DateTimeStamp(sent)
-
-/*
-Instance: INVALID-Communication-DispenseRequest-DiGA
-InstanceOf: GEM_ERP_PR_Communication_DispReq
-Title: "Communication message sent by patient to insurance company to request the dispensation of a DiGA by providing the AccessCode"
-Usage: #example
-* meta.tag.display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
-* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
-* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#162 "Flowtype für Digitale Gesundheitsanwendungen"
-* basedOn.reference = "Task/162.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
-* status = #unknown
-* recipient[+].identifier.system = $identifier-telematik-id
-* recipient[=].identifier.value = "8-SMC-B-Testkarte-883110000123465"
-* sender.identifier.system = $identifier-kvid-10
-* sender.identifier.value = "X234567890"
-* insert DateTimeStamp(sent)
-* payload.contentString = "U.N.V.E.U"
-
-Instance: INVALID-Communication-DispenseRequest-INV-flowType
-InstanceOf: GEM_ERP_PR_Communication_DispReq
-Title: "UNGÜLTIG: DiGA-Abgabe-Anfrage mit falschem FlowType"
-Description: "Ungültiges Beispiel für eine DiGA-Abgabe-Anfrage mit inkorrektem FlowType zur Validierung"
-Usage: #example
-* meta.tag.display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
-* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
-* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#162 "Flowtype für Digitale Gesundheitsanwendungen"
-* basedOn.reference = "Task/160.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
-* status = #unknown
-* recipient[+].identifier.system = $identifier-telematik-id
-* recipient[=].identifier.value = "8-SMC-B-Testkarte-883110000123465"
-* sender.identifier.system = $identifier-kvid-10
-* sender.identifier.value = "X234567890"
-* insert DateTimeStamp(sent)
-
-Instance: INVALID-Communication-DispenseRequest
-InstanceOf: GEM_ERP_PR_Communication_DispReq
-Title: "UNGÜLTIG: Abgabe-Anfrage ohne Payload"
-Description: "Ungültiges Beispiel für eine Abgabe-Anfrage ohne erforderlichen Payload-Inhalt zur Validierung"
-Usage: #example
-* meta.tag.display = "Communication message sent by patient to pharmacy to request the dispensation of medicine by providing the AccessCode"
-* extension[flowType].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
-* extension[flowType].valueCoding = https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType#160 "Flowtype für Apothekenpflichtige Arzneimittel"
-* basedOn.reference = "Task/160.000.033.491.280.78/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
-* status = #unknown
-* recipient[+].identifier.system = $identifier-telematik-id
-* recipient[=].identifier.value = "3-SMC-B-Testkarte-883110000123465"
-* sender.identifier.system = $identifier-kvid-10
-* sender.identifier.value = "X234567890"
-* insert DateTimeStamp(sent)
-*/
+Title: "Communication searchset response for Rx"
+Description: "Example response for GET /Communication"
+* type = #searchset
+* total = 1
+* link[+].relation = "self"
+* link[=].url = "https://erp-ref.example.org/Communication?_sort=sent&_count=50&sent=gt2025-01-14"
+* entry[+].fullUrl = "https://erp-ref.example.org/Communication/ExampleCommunicationDispReq"
+* entry[=].resource = ExampleCommunicationDispReq
+* entry[=].search.mode = #match

--- a/igs/rx/input/fsh/examples/communication_examples/Example_Communication_Reply.fsh
+++ b/igs/rx/input/fsh/examples/communication_examples/Example_Communication_Reply.fsh
@@ -1,25 +1,19 @@
-Instance: Communication_Reply_Pharmacy
+Instance: ExampleCommunicationReplyPharmacy
 InstanceOf: GEM_ERP_PR_Communication_Reply
 Title: "Antwort-Nachricht der Apotheke an den Patienten"
 Description: "Beispiel für eine Antwort-Nachricht, die von der Apotheke an den Patienten als Antwort auf eine vorherige Task-bezogene Nachricht gesendet wird"
 Usage: #example
-* id = "7977a4ab-97a9-4d95-afb3-6c4c1e2ac596"
 * meta.tag[+].display = "Reply from Pharmacy to Patient"
 * meta.tag[+].display = "Communication message sent by pharmacy to patient in response to a previous Task-related message"
 * basedOn.reference = "Task/160.000.033.491.280.78"
-* status = #unknown
-* sender.identifier.system = $identifier-telematik-id
-* sender.identifier.value = "3-SMC-B-Testkarte-883110000123465"
-* recipient.identifier.system = $identifier-kvid-10
-* recipient.identifier.value = "X234567890"
+* insert GKV_Identifier(recipient.identifier)
+* insert ApoTelematikID(sender.identifier)
 * insert DateTimeStamp(sent)
-* payload.extension[AvailabilityStatus]
-  * url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AvailabilityState"
-  * valueCoding.system = "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_AvailabilityStatus"
-  * valueCoding.code = #20
+* status = #unknown
+* payload.contentString = "{\"version\": 1,\"supplyOptionsType\": \"onPremise\",\"info_text\": \"Hallo, wir haben das Medikament vorraetig. Kommen Sie gern in die Filiale oder wir schicken einen Boten.\",\"url\": \"https://sonnenschein-apotheke.de\"}"
 * payload.extension[OfferedSupplyOptions]
-  * url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_SupplyOptionsType"
   * extension[onPremise].valueBoolean = true
-  * extension[shipment].valueBoolean = false
   * extension[delivery].valueBoolean = true
-* payload.contentString = "Eisern"
+  * extension[shipment].valueBoolean = false
+* payload.extension[AvailabilityStatus]
+  * valueCoding = $cs-availability-status#20

--- a/igs/rx/input/fsh/examples/communication_examples/Example_Communication_Reply.fsh
+++ b/igs/rx/input/fsh/examples/communication_examples/Example_Communication_Reply.fsh
@@ -3,8 +3,6 @@ InstanceOf: GEM_ERP_PR_Communication_Reply
 Title: "Antwort-Nachricht der Apotheke an den Patienten"
 Description: "Beispiel für eine Antwort-Nachricht, die von der Apotheke an den Patienten als Antwort auf eine vorherige Task-bezogene Nachricht gesendet wird"
 Usage: #example
-* meta.tag[+].display = "Reply from Pharmacy to Patient"
-* meta.tag[+].display = "Communication message sent by pharmacy to patient in response to a previous Task-related message"
 * basedOn.reference = "Task/160.000.033.491.280.78"
 * insert GKV_Identifier(recipient.identifier)
 * insert ApoTelematikID(sender.identifier)

--- a/igs/rx/input/fsh/profiles/GEM_ERP_PR_Communication.fsh
+++ b/igs/rx/input/fsh/profiles/GEM_ERP_PR_Communication.fsh
@@ -9,11 +9,9 @@ Description: "Generische Workflow-Communication"
 * basedOn 1..1 MS
 * basedOn only Reference(GEM_ERP_PR_Task)
 * basedOn ^type.aggregation = #referenced
-  * ^short = "Referenz zum E-Rezept-Task"
-  * ^comment = "Hat die Form 'Task/{{PrescriptionID}}'"
   * reference 1..1 MS
     * ^short = "Referenz zum E-Rezept-Task"
-    * ^comment = "Hat die Form 'Task/{{PrescriptionID}}'"
+    * ^comment = "Hat die Form 'Task/{{TaskID}}'"
 
 
 

--- a/igs/rx/input/fsh/profiles/GEM_ERP_PR_Communication.fsh
+++ b/igs/rx/input/fsh/profiles/GEM_ERP_PR_Communication.fsh
@@ -11,7 +11,7 @@ Description: "Generische Workflow-Communication"
 * basedOn ^type.aggregation = #referenced
   * reference 1..1 MS
     * ^short = "Referenz zum E-Rezept-Task"
-    * ^comment = "Hat die Form 'Task/{{TaskID}}'"
+    * ^comment = "Hat die Form 'Task/{{PrescriptionID}}'"
 
 
 

--- a/igs/rx/input/fsh/rulesets/Task.fsh
+++ b/igs/rx/input/fsh/rulesets/Task.fsh
@@ -5,3 +5,10 @@ RuleSet: GKV_Identifier(field)
 * insert KVNR({field}.value)
 * {field}.system = $identifier-kvid-10
 * {field}.assigner.identifier.value = "168140950"
+
+RuleSet: ApoTelematikID(field)
+* {field}.system = $identifier-telematik-id
+* {field}.value = "3-2-APO-XanthippeVeilchenblau01"
+
+RuleSet: TaskExension(flowType)
+* extension[flowType].valueCoding = $cs-flowtype#{flowType}

--- a/igs/rx/input/fsh/valuesets/GEM_ERP_VS_OrganizationType.fsh
+++ b/igs/rx/input/fsh/valuesets/GEM_ERP_VS_OrganizationType.fsh
@@ -2,5 +2,5 @@ ValueSet: GEM_ERP_VS_OrganizationType
 Id: GEM-ERP-VS-OrganizationType
 Title: "Bearbeiter eines E-Rezeptes"
 Description: "ValueSet der Organisationstyp-Codes eines Performers für den RX Task"
-* insert LegacyValueSet(GEM_ERP_VS_AvailabilityStatus)
+* insert LegacyValueSet(GEM_ERP_VS_OrganizationType)
 * include https://gematik.de/fhir/directory/CodeSystem/OrganizationProfessionOID#1.2.276.0.76.4.54 "Öffentliche Apotheke"

--- a/igs/rx/input/pagecontent/query-api-communication.md
+++ b/igs/rx/input/pagecontent/query-api-communication.md
@@ -39,16 +39,16 @@ Der Aufruf erfolgt als http-POST-Operation. Der Server prüft die Nachricht auf 
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
 	</div>
-<!--
+
 	<div id="Response-Examples">
 		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
-			{% fragment Communication/7977a4ab-97a9-4d95-afb3-6c4c1e2ac596 JSON %}
+			{% fragment Communication/ExampleCommunicationReplyPharmacy JSON %}
 		</div>
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Communication/7977a4ab-97a9-4d95-afb3-6c4c1e2ac596 XML %}
+			{% fragment Communication/ExampleCommunicationReplyPharmacy XML %}
 		</div>
 	</div>
--->
+
 </div>
 
 #### Abrufen von Communications
@@ -65,16 +65,16 @@ Als Apotheke oder Kostenträger möchten wir alle Nachrichten des Monats April 2
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
 	</div>
-<!--
+
 	<div id="Response-Examples">
 		<div data-name="application/fhir+json" data-type="JSON" data-render="ig-Fragment">
-			{% fragment Bundle/ExampleRxCommunicationSearchset JSON %}
+			{% fragment Bundle/ExampleCommunicationGetDispReq JSON %}
 		</div>
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Bundle/ExampleRxCommunicationSearchset XML %}
+			{% fragment Bundle/ExampleCommunicationGetDispReq XML %}
 		</div>
 	</div>
--->
+
 </div>
 
 ### Instance API
@@ -92,13 +92,13 @@ Um spezifische Details zu einer einzelnen _Communciation_ mittels der RESTful AP
 			{% include CapabilityStatement-ti-flow-fachdienst-server-rx.json %}
 		</pre>
 	</div>
-<!--
+
 	<div id="Response-Examples">
 		<div data-name="application/fhir+xml" data-type="XML" data-render="ig-Fragment">
-			{% fragment Bundle/ExampleRxCommunicationSearchset XML %}
+			{% fragment Bundle/ExampleCommunicationGetDispReq XML %}
 		</div>
 	</div>
--->
+
 </div>
 
 #### Löschen von Communications


### PR DESCRIPTION
**Beschreibung**

Für die TI-Flow-FD-RX-Schnittstelle sollen die bestehenden Communication-Beispiele überprüft, mit den aktuellen Profilen abgeglichen und anhand der Referenzbeispiele aus dem Projekt [gematik/eRezept-Examples](https://github.com/gematik/eRezept-Examples/tree/2026-07-01) angepasst werden.

Betroffen sind die Profile:
- GEM_ERP_PR_Communication
- GEM_ERP_PR_Communication_Reply
- GEM_ERP_PR_Communication_DispReq

Die zugehörigen Beispiele befinden sich in [gematik/eRezept-Examples](https://github.com/gematik/eRezept-Examples/tree/2026-07-01): igs/rx/input/fsh/examples/communication_examples/
